### PR TITLE
feat: implement rate limiting for feedback API

### DIFF
--- a/src/app/api/send-feedback/route.ts
+++ b/src/app/api/send-feedback/route.ts
@@ -3,24 +3,34 @@ import { NextRequest, NextResponse } from 'next/server';
 import { clientConfig, isValidEmail, sanitizeHTML } from '@/utils';
 import { mailOptions, transporter } from '@/utils/node-mailer';
 
-// In-memory store for IPs and request counts (Limit: 5 requests per minute per user)
+// --- Rate Limiting Logic ---
 const rateLimitMap = new Map<string, { count: number; lastReset: number }>();
 const LIMIT = 5;
 const WINDOW_MS = 60 * 1000;
 
+// Periodic cleanup to prevent memory leaks (Fix for CodeRabbit)
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, value] of rateLimitMap) {
+    if (now - value.lastReset > WINDOW_MS) {
+      rateLimitMap.delete(key);
+    }
+  }
+}, WINDOW_MS);
+
 export async function POST(request: NextRequest) {
+  // Identify user IP and trim it (Fix for CodeRabbit)
   const forwarded = request.headers.get('x-forwarded-for');
-  const ip = forwarded ? forwarded.split(',')[0] : '127.0.0.1';
+  const ip = forwarded ? forwarded.split(',')[0].trim() : '127.0.0.1';
+
   const now = Date.now();
   const userData = rateLimitMap.get(ip) || { count: 0, lastReset: now };
 
-  // Reset counter if the time window has passed
   if (now - userData.lastReset > WINDOW_MS) {
     userData.count = 0;
     userData.lastReset = now;
   }
 
-  // Check if user exceeded the limit
   if (userData.count >= LIMIT) {
     return NextResponse.json(
       { message: 'Too many requests, please try again later.' },
@@ -28,19 +38,30 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // We only increment AFTER parsing the body to be fair to the user
+  let body: { name: string; email: string; message: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { message: 'Invalid JSON body' },
+      { status: 400, statusText: 'Bad Request' }
+    );
+  }
+
   userData.count++;
   rateLimitMap.set(ip, userData);
 
+  const { name, email, message } = body;
+
+  if (!name || !email || !isValidEmail(email) || !message) {
+    return NextResponse.json(
+      { message: 'Invalid data' },
+      { status: 422, statusText: 'Unprocessable Entity' }
+    );
+  }
+
   try {
-    const { name, email, message } = await request.json();
-
-    if (!name || !email || !isValidEmail(email) || !message) {
-      return NextResponse.json(
-        { message: 'Invalid data' },
-        { status: 422, statusText: 'Unprocessable Entity' }
-      );
-    }
-
     const safeName = sanitizeHTML(name);
     const safeEmail = sanitizeHTML(email);
     const safeMessage = sanitizeHTML(message);
@@ -48,28 +69,20 @@ export async function POST(request: NextRequest) {
     await transporter.sendMail({
       ...mailOptions,
       subject: `${clientConfig.APP_NAME} - feedback`,
-      text: `Contact form submitted from ${clientConfig.APP_NAME}\n
-    Name: ${safeName}\n
-    Email: ${safeEmail}\n
-    Message: ${safeMessage}`,
+      text: `Contact form submitted from ${clientConfig.APP_NAME}\nName: ${safeName}\nEmail: ${safeEmail}\nMessage: ${safeMessage}`,
       html: `
         <section style="font-family: Arial, sans-serif; color: #333; padding: 20px;">
-          <header>
-            <h1 style="color: #0066cc;">Contact form submitted from ${clientConfig.APP_NAME}</h1>
-          </header>
+          <header><h1 style="color: #0066cc;">Contact form submitted from ${clientConfig.APP_NAME}</h1></header>
           <p><strong>Name:</strong> ${safeName}</p>
           <p><strong>Email:</strong> ${safeEmail}</p>
           <p><strong>Message:</strong> ${safeMessage}</p>
-        </section>
-      `,
+        </section>`,
     });
 
     return NextResponse.json({ message: 'Feedback sent successfully' });
   } catch {
     return NextResponse.json(
-      {
-        message: 'Failed to send feedback, Please try again later.',
-      },
+      { message: 'Failed to send feedback, Please try again later.' },
       { status: 500, statusText: 'Internal Server Error' }
     );
   }


### PR DESCRIPTION
## Description
This PR addresses the security concern where the feedback endpoint was vulnerable to spam/abuse. I have implemented an in-memory rate limiting mechanism to restrict requests from the same IP address.

## Changes
- Added a `rateLimitMap` to track user requests by IP.
- Implemented a threshold of 5 requests per minute.
- Returns a `429 Too Many Requests` status code when the limit is exceeded.

## Testing
- Verified through browser console that the first 5 requests are processed.
- Verified that subsequent requests (6+) correctly return status 429.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented per-IP rate limiting on feedback submissions (5 requests per minute) to improve reliability.
  * Exceeding the limit now returns a clear 429 response when too many submissions are made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->