### PR TITLE
Feat/sync filters with url state

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "jotai-devtools": "^0.12.0",
     "next": "^15.4.2",
     "nodemailer": "^6.10.0",
+    "nuqs": "^2.8.8",
     "react": "^19.1.0",
     "react-audio-spectrum": "^0.1.5",
     "react-dom": "^19.1.0",

--- a/src/app/api/reciters/route.ts
+++ b/src/app/api/reciters/route.ts
@@ -28,11 +28,6 @@ export async function GET(request: NextRequest) {
     }
 
     if (!response.ok) {
-      console.error(
-        '[API /api/reciters] mp3quran.net response not ok:',
-        response.status,
-        response.statusText
-      );
       return NextResponse.json(
         { error: 'Failed to fetch reciters' },
         { status: response.status }
@@ -40,14 +35,8 @@ export async function GET(request: NextRequest) {
     }
 
     const data = await response.json();
-    console.log(
-      '[API /api/reciters] Successfully fetched:',
-      data.reciters?.length || 0,
-      'reciters'
-    );
     return NextResponse.json(data);
-  } catch (error) {
-    console.error('[API /api/reciters] Error:', error);
+  } catch {
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/src/app/api/reciters/route.ts
+++ b/src/app/api/reciters/route.ts
@@ -28,6 +28,11 @@ export async function GET(request: NextRequest) {
     }
 
     if (!response.ok) {
+      console.error(
+        '[API /api/reciters] mp3quran.net response not ok:',
+        response.status,
+        response.statusText
+      );
       return NextResponse.json(
         { error: 'Failed to fetch reciters' },
         { status: response.status }
@@ -35,8 +40,14 @@ export async function GET(request: NextRequest) {
     }
 
     const data = await response.json();
+    console.log(
+      '[API /api/reciters] Successfully fetched:',
+      data.reciters?.length || 0,
+      'reciters'
+    );
     return NextResponse.json(data);
-  } catch {
+  } catch (error) {
+    console.error('[API /api/reciters] Error:', error);
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,16 @@
 'use client';
 import './globals.css';
 
-import { useAtom, useAtomValue } from 'jotai';
-import type { Metadata } from 'next';
-import { Tajawal } from 'next/font/google';
-import { use, useEffect } from 'react';
-
 import ExitFullscreen from '@/components/exit-fullscreen';
 import Footer from '@/components/footer';
 import HtmlWrapper from '@/components/html-wrapper';
 import IntlProviderWrapper from '@/components/intl-provider-wrapper';
 import LanguageSwitcher from '@/components/language-switcher';
 import { fullscreenAtom } from '@/jotai/atom';
+import { useAtom } from 'jotai';
+import { Tajawal } from 'next/font/google';
+import { NuqsAdapter } from 'nuqs/adapters/next/app';
+import { useEffect } from 'react';
 const tajawal = Tajawal({
   weight: ['400', '700', '900'],
   subsets: ['arabic'],
@@ -37,19 +36,21 @@ export default function RootLayout({
   }, [setIsFullscreen]);
 
   return (
-    <IntlProviderWrapper>
-      <HtmlWrapper>
-        <body className={`${tajawal.className} antialiased`}>
-          <main className="relative flex min-h-dvh w-full flex-col items-center justify-center text-foreground">
-            {isFullscreen ? <ExitFullscreen /> : <></>}
-            {isFullscreen ? <></> : <LanguageSwitcher />}
-            <div className="flex w-full flex-grow items-center justify-center">
-              {children}
-            </div>
-            {isFullscreen ? <></> : <Footer />}
-          </main>
-        </body>
-      </HtmlWrapper>
-    </IntlProviderWrapper>
+    <NuqsAdapter>
+      <IntlProviderWrapper>
+        <HtmlWrapper>
+          <body className={`${tajawal.className} antialiased`}>
+            <main className="relative flex min-h-dvh w-full flex-col items-center justify-center text-foreground">
+              {isFullscreen ? <ExitFullscreen /> : <></>}
+              {isFullscreen ? <></> : <LanguageSwitcher />}
+              <div className="flex w-full flex-grow items-center justify-center">
+                {children}
+              </div>
+              {isFullscreen ? <></> : <Footer />}
+            </main>
+          </body>
+        </HtmlWrapper>
+      </IntlProviderWrapper>
+    </NuqsAdapter>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,17 @@
 'use client';
 import './globals.css';
 
+import { useAtom } from 'jotai';
+import { Tajawal } from 'next/font/google';
+import { NuqsAdapter } from 'nuqs/adapters/next/app';
+import { useEffect } from 'react';
+
 import ExitFullscreen from '@/components/exit-fullscreen';
 import Footer from '@/components/footer';
 import HtmlWrapper from '@/components/html-wrapper';
 import IntlProviderWrapper from '@/components/intl-provider-wrapper';
 import LanguageSwitcher from '@/components/language-switcher';
 import { fullscreenAtom } from '@/jotai/atom';
-import { useAtom } from 'jotai';
-import { Tajawal } from 'next/font/google';
-import { NuqsAdapter } from 'nuqs/adapters/next/app';
-import { useEffect } from 'react';
 const tajawal = Tajawal({
   weight: ['400', '700', '900'],
   subsets: ['arabic'],

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,19 @@
 'use client';
 
-import { useAtomValue } from 'jotai';
+import { useAtom } from 'jotai';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import ReciterSelector from '@/components/reciter-selector';
 import UnderConstruction from '@/components/under-construction';
+import { useReciters } from '@/hooks/use-reciters';
 import { selectedReciterAtom } from '@/jotai/atom';
 
 import Logo from '../components/hero';
 
 export default function Home() {
-  const selectedReciter = useAtomValue(selectedReciterAtom);
+  const [selectedReciter, setSelectedReciter] = useAtom(selectedReciterAtom);
+  const { reciters, loading } = useReciters();
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -21,15 +23,46 @@ export default function Home() {
     setIsClient(true);
   }, []);
 
+  // Validate selectedReciter exists in reciters list
   useEffect(() => {
-    if (!isClient || !selectedReciter) return;
+
+    if (!isClient || loading || reciters.length === 0) return;
+
+    if (selectedReciter) {
+      const exists = reciters.some((r) => r.id === selectedReciter.id);
+      if (!exists) {
+        // Clear invalid reciter
+        console.warn('[Home] Clearing invalid reciter from home page');
+        setSelectedReciter(null);
+        return;
+      }
+    }
+  }, [isClient, loading, reciters, selectedReciter, setSelectedReciter]);
+
+  useEffect(() => {
+    if (!isClient || !selectedReciter || loading) return;
+
+    // Verify reciter exists before redirecting
+    const exists = reciters.some((r) => r.id === selectedReciter.id);
+    if (!exists) {
+      console.warn('[Home] Reciter does not exist, not redirecting');
+      return;
+    }
+
     const currentPath = `${pathname}?${searchParams.toString()}`;
     const targetPath = `/reciter/${selectedReciter.id}?moshafId=${selectedReciter.moshaf.id}`;
-
     if (currentPath !== targetPath) {
       router.push(targetPath);
     }
-  }, [selectedReciter, pathname, searchParams, router, isClient]);
+  }, [
+    selectedReciter,
+    pathname,
+    searchParams,
+    router,
+    isClient,
+    loading,
+    reciters,
+  ]);
 
   if (!isClient) {
     return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,8 +30,6 @@ export default function Home() {
     if (selectedReciter) {
       const exists = reciters.some((r) => r.id === selectedReciter.id);
       if (!exists) {
-        // Clear invalid reciter
-        console.warn('[Home] Clearing invalid reciter from home page');
         setSelectedReciter(null);
         return;
       }
@@ -43,10 +41,7 @@ export default function Home() {
 
     // Verify reciter exists before redirecting
     const exists = reciters.some((r) => r.id === selectedReciter.id);
-    if (!exists) {
-      console.warn('[Home] Reciter does not exist, not redirecting');
-      return;
-    }
+    if (!exists) return;
 
     const currentPath = `${pathname}?${searchParams.toString()}`;
     const targetPath = `/reciter/${selectedReciter.id}?moshafId=${selectedReciter.moshaf.id}`;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,7 +25,6 @@ export default function Home() {
 
   // Validate selectedReciter exists in reciters list
   useEffect(() => {
-
     if (!isClient || loading || reciters.length === 0) return;
 
     if (selectedReciter) {

--- a/src/app/reciter/[id]/page.tsx
+++ b/src/app/reciter/[id]/page.tsx
@@ -72,13 +72,15 @@ export default async function Page({ params }: Props) {
   let RECITERS = [];
   try {
     RECITERS = await getAllReciters();
-  } catch {
+  } catch (error) {
+    console.error('[ReciterPage] Error fetching reciters:', error);
     return notFound();
   }
 
   const reciter = RECITERS.find((r) => r.id === Number(id));
 
   if (!reciter) {
+    console.warn('[ReciterPage] Reciter not found for ID:', id);
     return notFound();
   }
 

--- a/src/app/reciter/[id]/page.tsx
+++ b/src/app/reciter/[id]/page.tsx
@@ -72,15 +72,14 @@ export default async function Page({ params }: Props) {
   let RECITERS = [];
   try {
     RECITERS = await getAllReciters();
-  } catch (error) {
-    console.error('[ReciterPage] Error fetching reciters:', error);
+  } catch {
     return notFound();
   }
 
+  // Find reciter with matching ID (there may be multiple entries with different moshafs)
   const reciter = RECITERS.find((r) => r.id === Number(id));
 
   if (!reciter) {
-    console.warn('[ReciterPage] Reciter not found for ID:', id);
     return notFound();
   }
 

--- a/src/components/reciter-selector.tsx
+++ b/src/components/reciter-selector.tsx
@@ -1,10 +1,5 @@
 'use client';
 
-import { useFavorites } from '@/hooks/use-favorites';
-import { selectedReciterAtom } from '@/jotai/atom';
-import searchSVG from '@/svgs/search.svg';
-import { generateFavId } from '@/utils';
-import { useShareReciter } from '@/utils/share';
 import { useAtomValue } from 'jotai';
 import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
@@ -12,6 +7,12 @@ import { useEffect, useRef, useState } from 'react';
 import { BsStar, BsStarFill } from 'react-icons/bs';
 import { FaRegShareFromSquare } from 'react-icons/fa6';
 import { useIntl } from 'react-intl';
+
+import { useFavorites } from '@/hooks/use-favorites';
+import { selectedReciterAtom } from '@/jotai/atom';
+import searchSVG from '@/svgs/search.svg';
+import { generateFavId } from '@/utils';
+import { useShareReciter } from '@/utils/share';
 
 import ReciterSelectorDialog from './reciter-selector-dialog';
 

--- a/src/components/reciter-selector.tsx
+++ b/src/components/reciter-selector.tsx
@@ -1,32 +1,41 @@
 'use client';
 
-import { useAtomValue } from 'jotai';
-import Image from 'next/image';
-import { useEffect, useState } from 'react';
-import { BsStar, BsStarFill } from 'react-icons/bs';
-import { FaRegShareFromSquare } from 'react-icons/fa6';
-import { useIntl } from 'react-intl';
-
 import { useFavorites } from '@/hooks/use-favorites';
 import { selectedReciterAtom } from '@/jotai/atom';
 import searchSVG from '@/svgs/search.svg';
 import { generateFavId } from '@/utils';
 import { useShareReciter } from '@/utils/share';
+import { useAtomValue } from 'jotai';
+import Image from 'next/image';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+import { BsStar, BsStarFill } from 'react-icons/bs';
+import { FaRegShareFromSquare } from 'react-icons/fa6';
+import { useIntl } from 'react-intl';
 
 import ReciterSelectorDialog from './reciter-selector-dialog';
 
 export default function ReciterSelector() {
   const [isOpen, setIsOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
+  const autoOpenedRef = useRef(false);
 
   const selectedReciter = useAtomValue(selectedReciterAtom);
   const { toggleFavorite, favoriteReciters } = useFavorites();
   const { formatMessage } = useIntl();
   const { shareReciter } = useShareReciter();
+  const searchParams = useSearchParams();
 
   useEffect(() => {
     setMounted(true);
-  }, []);
+
+    // Auto-open dialog if there's a search query in URL (only once)
+    const searchQuery = searchParams.get('q');
+    if (searchQuery && searchQuery.trim() !== '' && !autoOpenedRef.current) {
+      setIsOpen(true);
+      autoOpenedRef.current = true;
+    }
+  }, [searchParams]);
 
   if (!mounted) {
     // SSR and first client render will match here

--- a/src/components/reciter-selector.tsx
+++ b/src/components/reciter-selector.tsx
@@ -31,7 +31,7 @@ export default function ReciterSelector() {
     setMounted(true);
 
     // Auto-open dialog if there's a search query in URL (only once)
-    const searchQuery = searchParams.get('q');
+    const searchQuery = searchParams.get('query');
     if (searchQuery && searchQuery.trim() !== '' && !autoOpenedRef.current) {
       setIsOpen(true);
       autoOpenedRef.current = true;

--- a/src/components/reciters-list.tsx
+++ b/src/components/reciters-list.tsx
@@ -7,15 +7,15 @@ import { BsStar, BsStarFill } from 'react-icons/bs';
 import { ImSortAmountDesc } from 'react-icons/im';
 import { MdHistory } from 'react-icons/md';
 import {
-    TbSortAscendingLetters,
-    TbSortDescendingNumbers,
+  TbSortAscendingLetters,
+  TbSortDescendingNumbers,
 } from 'react-icons/tb';
 import { useIntl } from 'react-intl';
 
 import {
-    fetchViewCounts,
-    subscribeToViewCounts,
-    syncView,
+  fetchViewCounts,
+  subscribeToViewCounts,
+  syncView,
 } from '@/gun/view-rank';
 import { useFavorites } from '@/hooks/use-favorites';
 import { useFilterSort } from '@/hooks/use-filter-sort';
@@ -149,12 +149,12 @@ export default function RecitersList({ setIsOpen }: Props) {
       setIsOpen(false);
 
       // Preserve URL state (query, reciter parameters) when navigating
-      const params = new URLSearchParams(window.location.search);
-      const moshafParam = `moshafId=${reciter.moshaf.id}`;
-      const existingParams = params.toString();
-      const queryString = existingParams
-        ? `${moshafParam}&${existingParams}`
-        : moshafParam;
+      const parameters = new URLSearchParams(window.location.search);
+      const moshafParameter = `moshafId=${reciter.moshaf.id}`;
+      const existingParameters = parameters.toString();
+      const queryString = existingParameters
+        ? `${moshafParameter}&${existingParameters}`
+        : moshafParameter;
 
       router.push(`/reciter/${reciter.id}?${queryString}`);
     },

--- a/src/components/reciters-list.tsx
+++ b/src/components/reciters-list.tsx
@@ -6,15 +6,15 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { BsStar, BsStarFill } from 'react-icons/bs';
 import { ImSortAmountDesc } from 'react-icons/im';
 import {
-  TbSortAscendingLetters,
-  TbSortDescendingNumbers,
+    TbSortAscendingLetters,
+    TbSortDescendingNumbers,
 } from 'react-icons/tb';
 import { useIntl } from 'react-intl';
 
 import {
-  fetchViewCounts,
-  subscribeToViewCounts,
-  syncView,
+    fetchViewCounts,
+    subscribeToViewCounts,
+    syncView,
 } from '@/gun/view-rank';
 import { useFavorites } from '@/hooks/use-favorites';
 import { useFilterSort } from '@/hooks/use-filter-sort';
@@ -130,7 +130,16 @@ export default function RecitersList({ setIsOpen }: Props) {
       syncView(generateFavId(reciter));
       setSelectedReciter(reciter);
       setIsOpen(false);
-      router.push(`/reciter/${reciter.id}?moshafId=${reciter.moshaf.id}`);
+
+      // Preserve URL state (query, reciter parameters) when navigating
+      const params = new URLSearchParams(window.location.search);
+      const moshafParam = `moshafId=${reciter.moshaf.id}`;
+      const existingParams = params.toString();
+      const queryString = existingParams
+        ? `${moshafParam}&${existingParams}`
+        : moshafParam;
+
+      router.push(`/reciter/${reciter.id}?${queryString}`);
     },
     [router, setIsOpen, setSelectedReciter]
   );

--- a/src/components/reciters-list.tsx
+++ b/src/components/reciters-list.tsx
@@ -148,7 +148,7 @@ export default function RecitersList({ setIsOpen }: Props) {
       setSelectedReciter(reciter);
       setIsOpen(false);
 
-      // Preserve URL state (query, reciter parameters) when navigating
+      // Preserve URL state (query, riwaya parameters) when navigating
       const parameters = new URLSearchParams(window.location.search);
       const moshafParameter = `moshafId=${reciter.moshaf.id}`;
       const existingParameters = parameters.toString();
@@ -156,7 +156,8 @@ export default function RecitersList({ setIsOpen }: Props) {
         ? `${moshafParameter}&${existingParameters}`
         : moshafParameter;
 
-      router.push(`/reciter/${reciter.id}?${queryString}`);
+      const targetUrl = `/reciter/${reciter.id}?${queryString}`;
+      router.push(targetUrl);
     },
     [router, setIsOpen, setSelectedReciter, addToRecent]
   );

--- a/src/hooks/use-filter-sort.ts
+++ b/src/hooks/use-filter-sort.ts
@@ -10,7 +10,7 @@ import { Reciter, Riwaya } from '@/types';
 import { fuzzySearch, generateFavId } from '@/utils';
 
 // Define parsers for URL state management
-// Using shorter keys (q, r) for cleaner URLs
+// Using descriptive keys (query, reciter) for clarity
 // Define all possible Riwaya values plus 'all'
 const riwayaValues = ['all', ...Object.values(Riwaya)] as const;
 
@@ -36,12 +36,12 @@ export function useFilterSort({
   favoriteCounts = {},
   viewCounts = {},
 }: UseFilterSortParams) {
-  // Use nuqs for URL state management with shorter keys
+  // Use nuqs for URL state management with descriptive keys
   const [{ searchQuery: searchTerm, selectedRiwaya }, setFilters] =
     useQueryStates(filterSearchParsers, {
       urlKeys: {
-        searchQuery: 'q',
-        selectedRiwaya: 'r',
+        searchQuery: 'query',
+        selectedRiwaya: 'reciter',
       },
       history: 'push',
       shallow: false, // Allow server to track state changes

--- a/src/hooks/use-filter-sort.ts
+++ b/src/hooks/use-filter-sort.ts
@@ -10,7 +10,7 @@ import { Reciter, Riwaya } from '@/types';
 import { fuzzySearch, generateFavId } from '@/utils';
 
 // Define parsers for URL state management
-// Using descriptive keys (query, reciter) for clarity
+// Using descriptive keys (query, riwaya) for clarity
 // Define all possible Riwaya values plus 'all'
 const riwayaValues = ['all', ...Object.values(Riwaya)] as const;
 
@@ -41,7 +41,7 @@ export function useFilterSort({
     useQueryStates(filterSearchParsers, {
       urlKeys: {
         searchQuery: 'query',
-        selectedRiwaya: 'reciter',
+        selectedRiwaya: 'riwaya',
       },
       history: 'push',
       shallow: false, // Allow server to track state changes

--- a/src/hooks/use-reciters.ts
+++ b/src/hooks/use-reciters.ts
@@ -29,7 +29,15 @@ export function useReciters() {
 
         if (selectedReciter) {
           const matched = data.find((r) => r.id === selectedReciter.id);
-          setSelectedReciter(matched ?? null); // Reset if not found
+          if (matched) {
+            setSelectedReciter(matched); // Update with fresh data
+          } else {
+            console.warn(
+              '[useReciters] Clearing invalid reciter ID:',
+              selectedReciter.id
+            );
+            setSelectedReciter(null); // Clear invalid reciter
+          }
         }
       } catch {
         if (isMounted) {
@@ -49,7 +57,8 @@ export function useReciters() {
     return () => {
       isMounted = false;
     };
-  }, [locale, selectedReciter, setSelectedReciter]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Only fetch on locale change to avoid skeleton flicker
+  }, [locale, setSelectedReciter]);
 
   return { reciters, loading, error };
 }

--- a/src/hooks/use-reciters.ts
+++ b/src/hooks/use-reciters.ts
@@ -30,13 +30,9 @@ export function useReciters() {
         if (selectedReciter) {
           const matched = data.find((r) => r.id === selectedReciter.id);
           if (matched) {
-            setSelectedReciter(matched); // Update with fresh data
+            setSelectedReciter(matched);
           } else {
-            console.warn(
-              '[useReciters] Clearing invalid reciter ID:',
-              selectedReciter.id
-            );
-            setSelectedReciter(null); // Clear invalid reciter
+            setSelectedReciter(null);
           }
         }
       } catch {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -16,18 +16,27 @@ const generatePlaylist = (moshaf: MP3APIMoshaf): Playlist => {
   }));
   return result;
 };
-// Function to fetch reciters from MP3Quran API
+/**
+ * Fetches all reciters from MP3Quran API
+ *
+ * Note: Uses different URL strategy for server vs client to handle SSR:
+ * - Server-side: Calls mp3quran.net API directly with absolute URL
+ *   (Node.js fetch() requires absolute URLs, relative URLs throw "Invalid URL" error)
+ * - Client-side: Uses internal API route with relative URL
+ *   (Browser automatically resolves relative URLs to current domain)
+ *
+ * This prevents SSR failures when users directly visit reciter pages or refresh them.
+ */
 export async function getAllReciters(
   locale: 'ar' | 'en' = 'ar'
 ): Promise<Reciter[]> {
   const language = locale === 'en' ? 'eng' : 'ar';
 
-  // Determine if we're on server or client
+  // Server needs absolute URL, client works with relative URL
   const isServer = typeof window === 'undefined';
-  const baseUrl = isServer
-    ? process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
-    : '';
-  const url = `${baseUrl}/api/reciters?language=${language}`;
+  const url = isServer
+    ? `https://www.mp3quran.net/api/v3/reciters?language=${language}`
+    : `/api/reciters?language=${language}`;
 
   try {
     const response = await fetch(url, {
@@ -69,7 +78,13 @@ export async function getAllReciters(
   }
 }
 
-// Fetch reciter data from API
+/**
+ * Fetches a specific reciter's data from MP3Quran API
+ *
+ * Note: Uses different URL strategy for server vs client (same reason as getAllReciters):
+ * - Server-side: Direct API call with absolute URL to avoid "Invalid URL" errors
+ * - Client-side: Internal API route with relative URL for browser compatibility
+ */
 export async function getReciter(
   id: number,
   moshafId: number,
@@ -78,12 +93,11 @@ export async function getReciter(
   try {
     const language = locale === 'en' ? 'eng' : 'ar';
 
-    // Determine if we're on server or client
+    // Server needs absolute URL, client works with relative URL
     const isServer = typeof window === 'undefined';
-    const baseUrl = isServer
-      ? process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
-      : '';
-    const url = `${baseUrl}/api/reciters/${id}/${moshafId}?language=${language}`;
+    const url = isServer
+      ? `https://www.mp3quran.net/api/v3/reciters?language=${language}&reciter=${id}`
+      : `/api/reciters/${id}/${moshafId}?language=${language}`;
 
     const response = await fetch(url, { next: { revalidate: 3600 } });
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,9 +1,9 @@
 import {
-    LinkSource,
-    MP3APIMoshaf,
-    mp3QuranAPiResponse,
-    Reciter,
-    Riwaya,
+  LinkSource,
+  MP3APIMoshaf,
+  mp3QuranAPiResponse,
+  Reciter,
+  Riwaya,
 } from '@/types';
 import { Playlist } from '@/types/playlist';
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,9 +1,9 @@
 import {
-  LinkSource,
-  MP3APIMoshaf,
-  mp3QuranAPiResponse,
-  Reciter,
-  Riwaya,
+    LinkSource,
+    MP3APIMoshaf,
+    mp3QuranAPiResponse,
+    Reciter,
+    Riwaya,
 } from '@/types';
 import { Playlist } from '@/types/playlist';
 
@@ -21,12 +21,21 @@ export async function getAllReciters(
   locale: 'ar' | 'en' = 'ar'
 ): Promise<Reciter[]> {
   const language = locale === 'en' ? 'eng' : 'ar';
+
+  // Determine if we're on server or client
+  const isServer = typeof window === 'undefined';
+  const baseUrl = isServer
+    ? process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+    : '';
+  const url = `${baseUrl}/api/reciters?language=${language}`;
+
   try {
-    const response = await fetch(`/api/reciters?language=${language}`, {
+    const response = await fetch(url, {
       next: { revalidate: 3600 },
     });
 
     if (!response.ok) {
+      console.error('[getAllReciters] Response not ok:', response.statusText);
       throw new Error(`Failed to fetch reciters, ${response.statusText}`);
     }
 
@@ -56,7 +65,8 @@ export async function getAllReciters(
     }
 
     return reciters;
-  } catch {
+  } catch (error) {
+    console.error('[getAllReciters] Error:', error);
     return [];
   }
 }
@@ -69,10 +79,15 @@ export async function getReciter(
 ): Promise<Reciter | undefined> {
   try {
     const language = locale === 'en' ? 'eng' : 'ar';
-    const response = await fetch(
-      `/api/reciters/${id}/${moshafId}?language=${language}`,
-      { next: { revalidate: 3600 } }
-    );
+
+    // Determine if we're on server or client
+    const isServer = typeof window === 'undefined';
+    const baseUrl = isServer
+      ? process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+      : '';
+    const url = `${baseUrl}/api/reciters/${id}/${moshafId}?language=${language}`;
+
+    const response = await fetch(url, { next: { revalidate: 3600 } });
 
     if (!response.ok) return undefined;
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -35,7 +35,6 @@ export async function getAllReciters(
     });
 
     if (!response.ok) {
-      console.error('[getAllReciters] Response not ok:', response.statusText);
       throw new Error(`Failed to fetch reciters, ${response.statusText}`);
     }
 
@@ -65,8 +64,7 @@ export async function getAllReciters(
     }
 
     return reciters;
-  } catch (error) {
-    console.error('[getAllReciters] Error:', error);
+  } catch {
     return [];
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2840,6 +2840,11 @@
   dependencies:
     tslib "^2.6.2"
 
+"@standard-schema/spec@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.0.0.tgz#f193b73dc316c4170f2e82a881da0f550d551b9c"
+  integrity sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==
+
 "@standard-schema/spec@^1.0.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz"
@@ -7172,6 +7177,13 @@ nth-check@^2.0.1:
   integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
     boolbase "^1.0.0"
+
+nuqs@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/nuqs/-/nuqs-2.8.8.tgz#375be35455b1d7e1104a15ff4d840533d6c55f76"
+  integrity sha512-LF5sw9nWpHyPWzMMu9oho3r9C5DvkpmBIg4LQN78sexIzGaeRx8DWr0uy3YiFx5i2QGZN1Qqcb+OAtEVRa2bnA==
+  dependencies:
+    "@standard-schema/spec" "1.0.0"
 
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
This pull request introduces significant improvements to state management and user experience in the reciter selection and filtering features. The most impactful changes are the migration of search and filter state to the URL using the `nuqs` library, enabling deep linking and better browser navigation, as well as an enhancement that auto-opens the reciter selector dialog when a search query is present in the URL.

relted:  #8 

**State Management Improvements:**

* Migrated search and filter state (`searchTerm` and `selectedRiwaya`) in the `useFilterSort` hook to be managed via URL query parameters using the `nuqs` library, allowing for deep linking and improved browser navigation. Shorter query keys (`q`, `r`) are used for cleaner URLs. (`src/hooks/use-filter-sort.ts` [[1]](diffhunk://#diff-493fc1ff057e0cb4818226e41933b6be5505f777ad4fa122a57a7fb2c603a74dL4-R23) [[2]](diffhunk://#diff-493fc1ff057e0cb4818226e41933b6be5505f777ad4fa122a57a7fb2c603a74dL26-R50) [[3]](diffhunk://#diff-493fc1ff057e0cb4818226e41933b6be5505f777ad4fa122a57a7fb2c603a74dL96-R122)
* Added `nuqs` as a dependency in `package.json`. (`package.json` [package.jsonR42](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R42))
* Wrapped the app in `NuqsAdapter` in `layout.tsx` to enable URL state management throughout the application. (`src/app/layout.tsx` [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L4-R7) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R40) [[3]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R55)

**User Experience Enhancements:**

* Updated the `ReciterSelector` component to automatically open the selector dialog if a search query is present in the URL, improving discoverability and navigation for users arriving via links with search parameters. (`src/components/reciter-selector.tsx` [[1]](diffhunk://#diff-a279ec4d54219dd5fe89627c7674f5b9abbd90a42cd674797ce514237a8ccd6cL5-R6) [[2]](diffhunk://#diff-a279ec4d54219dd5fe89627c7674f5b9abbd90a42cd674797ce514237a8ccd6cR22-R39)