### PR TITLE
fix: replace NodeJS.Timeout with portable type

### DIFF
--- a/src/hooks/use-sleep-timer.ts
+++ b/src/hooks/use-sleep-timer.ts
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 
 export const useSleepTimer = (togglePlayPause: () => void) => {
-  const [sleepTimerId, setSleepTimerId] = useState<NodeJS.Timeout | null>(null);
+  const [sleepTimerId, setSleepTimerId] = useState<ReturnType<typeof setTimeout> | null>(null);
   const [remainingTime, setRemainingTime] = useState<number | null>(null);
 
   // Real-time countdown (for accurate pause)
   useEffect(() => {
-    let interval: NodeJS.Timeout | null = null;
+    let interval: ReturnType<typeof setTimeout> | null = null;
     if (remainingTime !== null && remainingTime > 0) {
       interval = setInterval(() => {
         setRemainingTime((previous) =>


### PR DESCRIPTION
## Summary
- Replaced `NodeJS.Timeout` with `ReturnType<typeof setTimeout>` in `src/hooks/use-sleep-timer.ts`
- This ensures compatibility with browser environments where `NodeJS.Timeout` may not be available

## Changes
- `src/hooks/use-sleep-timer.ts`: 2 occurrences of `NodeJS.Timeout` replaced with `ReturnType<typeof setTimeout>`

## Test plan
- [ ] Verify sleep timer works in browser environment
- [ ] Verify sleep timer works in Node.js environment
- [ ] TypeScript compilation passes without errors

Closes #12