### PR TITLE
Fix sleep timer type

### DIFF
--- a/src/hooks/use-sleep-timer.ts
+++ b/src/hooks/use-sleep-timer.ts
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 
 export const useSleepTimer = (togglePlayPause: () => void) => {
-  const [sleepTimerId, setSleepTimerId] = useState<NodeJS.Timeout | null>(null);
+  const [sleepTimerId, setSleepTimerId] = useState<ReturnType<typeof setTimeout> | null>(null);
   const [remainingTime, setRemainingTime] = useState<number | null>(null);
 
   // Real-time countdown (for accurate pause)
   useEffect(() => {
-    let interval: NodeJS.Timeout | null = null;
+    let interval: ReturnType<typeof setInterval> | null = null;
     if (remainingTime !== null && remainingTime > 0) {
       interval = setInterval(() => {
         setRemainingTime((previous) =>


### PR DESCRIPTION
## Description

This PR addresses a type compatibility issue in the `use-sleep-timer` hook.
It replaces the explicit `NodeJS.Timeout` type usage with `ReturnType<typeof setTimeout>`.

This change ensures that the timer ID is correctly typed across different environments (Browser vs Node.js). In browser environments, `setTimeout` typically returns a `number`, which conflicted with the `NodeJS.Timeout` type definition, causing build/lint errors. Using `ReturnType<typeof setTimeout>` dynamically infers the correct type provided by the environment.

Fixes #12

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- Verified that `use-sleep-timer.ts` no longer throws type errors during compilation.
- Confirmed that the sleep timer can still be set and cleared correctly within the application logic.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules