### PR TITLE
feat: add offline Mushaf download functionality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
      "@gun/*": "${workspaceRoot}/src/gun",
 
     },
-    "postman.settings.dotenv-detection-notification-visibility": false
+    "postman.settings.dotenv-detection-notification-visibility": false,
+    "i18n-ally.localesPaths": [
+        "src/locales"
+    ]
 }

--- a/src/app/reciter/[id]/reciter-page.tsx
+++ b/src/app/reciter/[id]/reciter-page.tsx
@@ -7,6 +7,7 @@ import React, { Suspense, useEffect } from 'react';
 import PwaUpdater from '@/components/pwa-updater';
 import ReciterSelector from '@/components/reciter-selector';
 import SimpleSkeleton from '@/components/simple-skeleton';
+import DownloadMushafButton from '@/components/download-mushaf-button';
 import { fullscreenAtom, selectedReciterAtom } from '@/jotai/atom';
 
 const Player = dynamic(() => import('@/components/player'), { ssr: false });
@@ -43,6 +44,9 @@ function ReciterContent() {
           <Suspense fallback={<SimpleSkeleton />}>
             <Player playlist={selectedReciter.moshaf.playlist} />
           </Suspense>
+        )}
+        {selectedReciter?.moshaf && !isFullscreen && (
+          <DownloadMushafButton playlist={selectedReciter.moshaf.playlist} />
         )}
         <PwaUpdater />
       </div>

--- a/src/components/download-mushaf-button.tsx
+++ b/src/components/download-mushaf-button.tsx
@@ -1,0 +1,345 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { FiCheck, FiDownload, FiLoader, FiPause, FiPlay, FiTrash2 } from 'react-icons/fi';
+import { useIntl } from 'react-intl';
+
+import { Playlist } from '@/types';
+
+type SizeInfo = { total: number; loaded: number };
+
+export default function DownloadMushafButton({
+    playlist,
+}: {
+    playlist: Playlist;
+}) {
+    const intl = useIntl();
+    const [status, setStatus] = useState<
+        'checking' | 'idle' | 'downloading' | 'paused' | 'downloaded'
+    >('checking');
+    const [overallProgress, setOverallProgress] = useState<number>(0);
+    const [overallTotal, setOverallTotal] = useState(0);
+    const [overallLoaded, setOverallLoaded] = useState(0);
+
+    const sizesRef = useRef<Record<string, SizeInfo>>({});
+    const isDownloadingRef = useRef(false);
+    const swRef = useRef<ServiceWorker | null>(null);
+    const activeUrlRef = useRef<string | null>(null);
+
+    // Helper to format bytes
+    const formatBytes = (bytes: number) => {
+        if (bytes === 0) return '0 B';
+        const k = 1024;
+        const sizes = ['B', 'KB', 'MB', 'GB'];
+        const i = Math.floor(Math.log(bytes) / Math.log(k));
+        return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+    };
+
+    // Helper to init SW reference
+    const getSW = async () => {
+        if (!('serviceWorker' in navigator)) return null;
+        try {
+            const registration = await navigator.serviceWorker.ready;
+            return registration.active;
+        } catch (e) {
+            return null;
+        }
+    };
+
+    // Check cache status on mount
+    useEffect(() => {
+        async function checkCacheStatus() {
+            const sw = await getSW();
+            if (!sw) {
+                setStatus('idle');
+                return;
+            }
+            swRef.current = sw;
+
+            let cachedCount = 0;
+            let sumSize = 0;
+
+            for (const item of playlist) {
+                try {
+                    const result = await new Promise<any>((resolve) => {
+                        const messageChannel = new MessageChannel();
+                        messageChannel.port1.onmessage = (event) => resolve(event.data);
+                        sw.postMessage({ action: 'CHECK_CACHED', url: item.link }, [messageChannel.port2]);
+                    });
+
+                    if (result.isCached) {
+                        cachedCount++;
+                        sizesRef.current[item.link] = { total: result.size || 0, loaded: result.size || 0 };
+                        sumSize += result.size || 0;
+                    }
+                } catch (e) {
+                    // Ignore
+                }
+            }
+
+            setOverallLoaded(sumSize);
+            if (cachedCount === playlist.length && playlist.length > 0) {
+                setOverallTotal(sumSize);
+                setStatus('downloaded');
+            } else {
+                setStatus('idle');
+            }
+        }
+
+        checkCacheStatus();
+    }, [playlist]);
+
+    // Sync isDownloadingRef with status
+    useEffect(() => {
+        if (status === 'downloading') {
+            isDownloadingRef.current = true;
+            startDownloadLoop();
+        } else {
+            isDownloadingRef.current = false;
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [status]);
+
+    const startDownloadLoop = async () => {
+        const sw = swRef.current;
+        if (!sw) return;
+
+        // Use a throttle for progress updates to avoid too many React re-renders
+        let lastRenderTime = 0;
+
+        for (const item of playlist) {
+            if (!isDownloadingRef.current) break;
+
+            const currentSize = sizesRef.current[item.link];
+            if (currentSize && currentSize.loaded >= currentSize.total && currentSize.total > 0) {
+                continue;
+            }
+
+            try {
+                await new Promise((resolve, reject) => {
+                    const messageChannel = new MessageChannel();
+                    messageChannel.port1.onmessage = (event) => {
+                        const data = event.data;
+                        if (data.progress) {
+                            if (!sizesRef.current[item.link]) {
+                                sizesRef.current[item.link] = { total: data.total, loaded: 0 };
+                            }
+                            sizesRef.current[item.link].loaded = data.loaded;
+                            sizesRef.current[item.link].total = data.total;
+
+                            // Throttle React state updates to ~every 200ms
+                            const now = Date.now();
+                            if (now - lastRenderTime > 200) {
+                                lastRenderTime = now;
+                                updateOverallProgress();
+                            }
+                        } else if (data.success) {
+                            if (!sizesRef.current[item.link]) {
+                                sizesRef.current[item.link] = { total: data.total, loaded: data.loaded };
+                            }
+                            sizesRef.current[item.link].loaded = data.total; // ensure it's 100% matched
+                            updateOverallProgress();
+                            resolve(data);
+                        } else if (data.aborted) {
+                            // User paused, which aborted the fetch. Reject to skip to next (which immediately breaks loop)
+                            reject(new Error('Aborted by user'));
+                        } else if (data.error) {
+                            reject(new Error(data.error));
+                        }
+                    };
+
+                    activeUrlRef.current = item.link;
+                    sw.postMessage({ action: 'CACHE_AUDIO', url: item.link }, [messageChannel.port2]);
+                });
+            } catch (error) {
+                if ((error as Error).message !== 'Aborted by user') {
+                    console.error('Failed to cache:', item.link, error);
+                }
+            } finally {
+                if (activeUrlRef.current === item.link) {
+                    activeUrlRef.current = null;
+                }
+            }
+        }
+
+        if (isDownloadingRef.current) {
+            // Finished looping naturally
+            let allDone = true;
+            for (const item of playlist) {
+                const s = sizesRef.current[item.link];
+                if (!s || s.loaded < s.total || s.total === 0) {
+                    allDone = false;
+                    break;
+                }
+            }
+
+            if (allDone && playlist.length > 0) {
+                setStatus('downloaded');
+                setOverallProgress(100);
+            } else {
+                setStatus('paused');
+            }
+        }
+    };
+
+    const updateOverallProgress = () => {
+        let sumLoaded = 0;
+        let sumTotal = 0;
+        let knownCount = 0;
+
+        // Default estimate: 3 MB per missing file
+        const DEFAULT_FILE_SIZE = 3 * 1024 * 1024;
+
+        Object.values(sizesRef.current).forEach((s) => {
+            sumLoaded += s.loaded;
+            if (s.total > 0) {
+                sumTotal += s.total;
+                knownCount++;
+            }
+        });
+
+        const averageSize = knownCount > 0 ? (sumTotal / knownCount) : DEFAULT_FILE_SIZE;
+        const unknownCount = Math.max(0, playlist.length - knownCount);
+        const estimatedTotal = sumTotal + (averageSize * unknownCount);
+
+        setOverallLoaded(sumLoaded);
+        setOverallTotal(estimatedTotal);
+        setOverallProgress(estimatedTotal > 0 ? Math.round((sumLoaded / estimatedTotal) * 100) : 0);
+    };
+
+    const handleDownload = async () => {
+        if (!('serviceWorker' in navigator)) {
+            alert('Service Worker is not supported in this browser.');
+            return;
+        }
+
+        const sw = swRef.current || (await getSW());
+        if (!sw) {
+            alert(
+                'Service Worker is not active. Please ensure it is enabled and you are running on localhost or https.'
+            );
+            return;
+        }
+        swRef.current = sw;
+
+        updateOverallProgress();
+        setStatus('downloading');
+    };
+
+    const handlePause = () => {
+        setStatus('paused');
+        if (activeUrlRef.current && swRef.current) {
+            swRef.current.postMessage({ action: 'ABORT_AUDIO', url: activeUrlRef.current });
+        }
+    };
+
+    const handleResume = () => {
+        setStatus('downloading');
+    };
+
+    const handleRemove = async () => {
+        const sw = swRef.current || (await getSW());
+        if (!sw) return;
+
+        setStatus('checking');
+
+        // Abort any active download
+        if (activeUrlRef.current) {
+            sw.postMessage({ action: 'ABORT_AUDIO', url: activeUrlRef.current });
+        }
+
+        for (const item of playlist) {
+            try {
+                await new Promise((resolve) => {
+                    const messageChannel = new MessageChannel();
+                    messageChannel.port1.onmessage = (event) => resolve(event.data);
+                    sw.postMessage({ action: 'REMOVE_AUDIO', url: item.link }, [messageChannel.port2]);
+                });
+            } catch (e) {
+                console.error('Failed to remove:', item.link, e);
+            }
+        }
+        sizesRef.current = {};
+        setOverallLoaded(0);
+        setOverallTotal(0);
+        setOverallProgress(0);
+        setStatus('idle');
+    };
+
+    if (status === 'checking') {
+        return (
+            <button
+                disabled
+                className="flex items-center gap-2 rounded-lg bg-gray-200 px-4 py-2 text-sm font-medium text-gray-400 transition-colors dark:bg-gray-800 dark:text-gray-500"
+            >
+                <FiLoader className="animate-spin" />
+                {intl.formatMessage({ id: 'mushaf.checkingStatus' })}
+            </button>
+        );
+    }
+
+
+    if (status === 'downloading') {
+        return (
+            <button
+                onClick={handlePause}
+                className="flex items-center gap-2 rounded-lg bg-emerald-100 px-4 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-200 transition-colors dark:bg-emerald-900/30 dark:text-emerald-400 dark:hover:bg-emerald-900/50"
+            >
+                <FiPause />
+                <span className="flex flex-col items-start gap-1 leading-tight text-left">
+                    <span>{intl.formatMessage({ id: 'mushaf.pauseDownload' }, { progress: overallProgress })}</span>
+                    <span className="text-xs opacity-80 font-normal" dir="ltr">
+                        {formatBytes(overallLoaded)} / {formatBytes(overallTotal)}
+                    </span>
+                </span>
+            </button>
+        );
+    }
+
+    if (status === 'paused') {
+        return (
+            <button
+                onClick={handleResume}
+                className="flex items-center gap-2 rounded-lg bg-amber-100 px-4 py-2 text-sm font-medium text-amber-700 hover:bg-amber-200 transition-colors dark:bg-amber-900/30 dark:text-amber-400 dark:hover:bg-amber-900/50"
+            >
+                <FiPlay />
+                <span className="flex flex-col items-start gap-1 leading-tight text-left">
+                    <span>{intl.formatMessage({ id: 'mushaf.resumeDownload' }, { progress: overallProgress })}</span>
+                    <span className="text-xs opacity-80 font-normal" dir="ltr">
+                        {formatBytes(overallLoaded)} / {formatBytes(overallTotal)}
+                    </span>
+                </span>
+            </button>
+        );
+    }
+
+    if (status === 'downloaded') {
+        return (
+            <button
+                onClick={handleRemove}
+                title={intl.formatMessage({ id: 'mushaf.removeOffline' })}
+                className="flex items-center gap-2 rounded-lg bg-emerald-100 px-4 py-2 text-sm font-medium text-emerald-700 hover:bg-red-100 hover:text-red-700 transition-colors dark:bg-emerald-900/30 dark:text-emerald-400 dark:hover:bg-red-900/30 dark:hover:text-red-400"
+            >
+                <FiTrash2 />
+                <span className="flex flex-col items-start gap-1 leading-tight text-left">
+                    <span>{intl.formatMessage({ id: 'mushaf.availableOffline' })}</span>
+                    {overallTotal > 0 && (
+                        <span className="text-xs opacity-80 font-normal" dir="ltr">
+                            {formatBytes(overallTotal)}
+                        </span>
+                    )}
+                </span>
+            </button>
+        );
+    }
+
+    return (
+        <button
+            onClick={handleDownload}
+            className="flex items-center gap-2 rounded-lg bg-blue-100 px-4 py-2 text-sm font-medium text-blue-700 hover:bg-blue-200 transition-colors dark:bg-blue-900/30 dark:text-blue-400 dark:hover:bg-blue-900/50"
+        >
+            <FiDownload />
+            {intl.formatMessage({ id: 'mushaf.download' })}
+        </button>
+    );
+}

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -1,9 +1,7 @@
 {
   "appName": "القرآن الكريم",
   "appDescription": "تلاوات تلامس القلب دون إلهاءات.",
-
   "close": "إغلاق",
-
   "footer.home": "الصفحة الرئيسية",
   "footer.about": "معلومات عن التطبيق",
   "footer.privacy": "سياسة الخصوصية",
@@ -21,7 +19,6 @@
   "showFavorite": "المفضلة فقط",
   "noRecitersFound": "لا يوجد قراء مطابقين للبحث.",
   "allReciters": "جميع الروايات",
-
   "riwaya.Hafs": "حفص",
   "riwaya.Warsh": "ورش",
   "riwaya.Qaloon": "قالون",
@@ -36,7 +33,6 @@
   "riwaya.Hisham": "هشام",
   "riwaya.IbnJammaz": "ابن جماز",
   "riwaya.Yaqoub": "يعقوب",
-
   "contact.please_enter_name": "يرجى إدخال اسمك",
   "contact.please_enter_email": "يرجى إدخال البريد الإلكتروني",
   "contact.please_enter_valid_email": "يرجى إدخال البريد الإلكتروني بشكل صحيح",
@@ -50,7 +46,6 @@
   "contact.name": "اسم",
   "contact.email": "بريد إلكتروني",
   "contact.message": "رسالة",
-
   "about.title": "حول تطبيق Quran.us.kg",
   "about.description": "Quran.us.kg هو تطبيق قرآن مفتوح المصدر صمم لتوفير تجربة استماع مثالية عبر مختلف المنصات. بُني التطبيق باستخدام تقنيات ويب حديثة لضمان:",
   "about.feature.performance": "أداء عالي السرعة واستجابة سريعة",
@@ -61,7 +56,6 @@
   "about.servers.description1": "يستخدم التطبيق ملفات الصوت عالية الجودة للقرآن الكريم التي توفرها خدمة mp3quran، وهي خدمة طرف ثالث مستقلة. هذه الخدمة تضمن استقرار وسرعة في تحميل الملفات، مما يتيح للمستخدمين الاستماع إلى التلاوات دون انقطاع أو تأخير.",
   "about.servers.description2": "نود التأكيد على أن mp3quran ليست جزءًا من خدماتنا، بل هي مزود خارجي يدعم ملايين المستخدمين حول العالم من خلال مكتبة صوتية واسعة ومتنوعة.",
   "about.footer.rights": "جميع الحقوق محفوظة",
-
   "privacy.title": "سياسة خصوصية Quran.us.kg",
   "privacy.effectiveDate": "تاريخ السريان: 14 فبراير 2025",
   "privacy.section1.title": "خصوصيتك مهمة بالنسبة لنا",
@@ -82,15 +76,12 @@
   "privacy.section7.body": "لا يستخدم Quran.us.kg أي خدمات طرف ثالث للتحليلات أو التتبع أو جمع البيانات. يعمل التطبيق بالكامل على جهازك دون إرسال أي معلومات خارجيًا.",
   "privacy.section8.title": "اتصل بنا",
   "privacy.section8.body": "إذا كانت لديك أي أسئلة حول هذه السياسة، فلا تتردد في الاتصال بنا على:",
-
   "share.message": "استمع إلى هذا القارئ على Tarteel",
   "share.fallback": "تم نسخ الرابط إلى الحافظة!",
   "share.fallback.error": "فشل نسخ الرابط.",
-
   "underConstruction.message": "التطبيق قيد التطوير",
   "underConstruction.doNotShowAgain": "لا تعرض هذا مرة أخرى",
   "underConstruction.title": "قيد الإنشاء",
-
   "player.play": "تشغيل",
   "player.pause": "إيقاف",
   "player.nextTrack": "التالي",
@@ -107,10 +98,15 @@
   "player.togglePlaylist": "قائمة التشغيل",
   "player.playbackSpeed": "سرعة التشغيل: {speed}x",
   "player.volumeControl": "تحكم بمستوى الصوت",
-
   "player.more": "المزيد",
-
   "player.sleepTimerActive": "مؤقت النوم نشط",
   "player.sleepTimer": "مؤقت النوم",
-  "player.untilEnd": "حتى نهاية التلاوة"
+  "player.untilEnd": "حتى نهاية التلاوة",
+  "mushaf.download": "تحميل المصحف",
+  "mushaf.checkingStatus": "جاري التحقق...",
+  "mushaf.calculatingSize": "جاري حساب الحجم...",
+  "mushaf.pauseDownload": "إيقاف التحميل مؤقتا ({progress}%)",
+  "mushaf.resumeDownload": "إكمال التحميل ({progress}%)",
+  "mushaf.availableOffline": "متاح بدون اتصال",
+  "mushaf.removeOffline": "حذف المصحف"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,9 +1,7 @@
 {
   "appName": "The Holy Quran",
   "appDescription": "Heartfelt recitations without distractions.",
-
   "close": "Close",
-
   "footer.home": "Home",
   "footer.about": "About the app",
   "footer.privacy": "Privacy Policy",
@@ -21,7 +19,6 @@
   "showFavorite": "Show Favorite",
   "noRecitersFound": "No reciters found.",
   "allReciters": "All Reciters",
-
   "riwaya.Hafs": "Hafs",
   "riwaya.Warsh": "Warsh",
   "riwaya.Qaloon": "Qaloon",
@@ -36,7 +33,6 @@
   "riwaya.Hisham": "Hisham",
   "riwaya.IbnJammaz": "Ibn Jammaz",
   "riwaya.Yaqoub": "Ya‘qoub",
-
   "contact.please_enter_name": "Please enter your name",
   "contact.please_enter_email": "Please enter your email",
   "contact.please_enter_valid_email": "Please enter a valid email",
@@ -50,7 +46,6 @@
   "contact.name": "Name",
   "contact.email": "Email",
   "contact.message": "Message",
-
   "about.title": "About Quran.us.kg App",
   "about.description": "Quran.us.kg is an open-source Quran app built to offer an ideal listening experience across all platforms. The app is built using modern web technologies to ensure:",
   "about.feature.performance": "High-speed performance and quick response",
@@ -61,7 +56,6 @@
   "about.servers.description1": "The app uses high-quality Quran audio files provided by mp3quran, a third-party independent service. This ensures fast and stable loading, enabling users to listen to recitations without interruption.",
   "about.servers.description2": "We emphasize that mp3quran is not part of our services. It is an external provider supporting millions of users worldwide with a vast and diverse audio library.",
   "about.footer.rights": "All rights reserved",
-
   "privacy.title": "Quran.us.kg Privacy Policy",
   "privacy.effectiveDate": "Effective Date: February 14, 2025",
   "privacy.section1.title": "Your Privacy Matters to Us",
@@ -82,15 +76,12 @@
   "privacy.section7.body": "Quran.us.kg does not use any third-party services for analytics, tracking, or data collection. The app works entirely on your device without sending any information externally.",
   "privacy.section8.title": "Contact Us",
   "privacy.section8.body": "If you have any questions about this policy, feel free to contact us at:",
-
   "share.message": "Listen to this reciter on Tarteel",
   "share.fallback": "Link copied to clipboard!",
   "share.fallback.error": "Failed to copy link.",
-
   "underConstruction.message": "The app is under development",
   "underConstruction.doNotShowAgain": "Do not show this message again",
   "underConstruction.title": "Under Construction",
-
   "player.play": "Play",
   "player.pause": "Pause",
   "player.nextTrack": "Next Track",
@@ -107,10 +98,15 @@
   "player.togglePlaylist": "Playlist",
   "player.playbackSpeed": "Playback speed: {speed}x",
   "player.volumeControl": "Volume control",
-
   "player.more": "More options",
-
   "player.sleepTimerActive": "Sleep timer active",
   "player.sleepTimer": "Sleep Timer",
-  "player.untilEnd": "Until the end of the recitation"
+  "player.untilEnd": "Until the end of the recitation",
+  "mushaf.download": "Download Mushaf",
+  "mushaf.checkingStatus": "Checking Status...",
+  "mushaf.calculatingSize": "Calculating Size...",
+  "mushaf.pauseDownload": "Pause Download ({progress}%)",
+  "mushaf.resumeDownload": "Resume Download ({progress}%)",
+  "mushaf.availableOffline": "Available Offline",
+  "mushaf.removeOffline": "Remove Offline Mushaf"
 }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -33,8 +33,8 @@ const quranAudioCache = {
     cacheName: 'quran-audio',
     plugins: [
       new ExpirationPlugin({
-        maxEntries: 20,
-        maxAgeSeconds: 7 * 24 * 60 * 60, // 7 days
+        maxEntries: 114, // Increase max entries to allow caching full moshaf if streaming
+        maxAgeSeconds: 30 * 24 * 60 * 60, // 30 days
       }),
       new CacheableResponsePlugin({
         statuses: [200],
@@ -55,3 +55,131 @@ const serwist = new Serwist({
 });
 
 serwist.addEventListeners();
+
+const abortControllers = new Map<string, AbortController>();
+
+// Add listener for caching audio and offline downloads
+self.addEventListener('message', async (event) => {
+  if (event.data && event.data.action === 'GET_FILE_SIZE') {
+    const { url } = event.data;
+    if (url) {
+      try {
+        const cache = await caches.open('quran-audio');
+        const cachedRes = await cache.match(url);
+        if (cachedRes) {
+          let size = 0;
+          const sizeStr = cachedRes.headers.get('content-length');
+          if (sizeStr) size = parseInt(sizeStr, 10);
+          else {
+            const blob = await cachedRes.clone().blob();
+            size = blob.size;
+          }
+          event.ports[0]?.postMessage({ success: true, url, size, cached: true });
+          return;
+        }
+
+        const headRes = await fetch(url, { method: 'HEAD' });
+        const sizeStr = headRes.headers.get('content-length');
+        const size = sizeStr ? parseInt(sizeStr, 10) : 0;
+        event.ports[0]?.postMessage({ success: true, url, size, cached: false });
+      } catch (error: any) {
+        event.ports[0]?.postMessage({ success: false, url, error: error.message });
+      }
+    }
+  } else if (event.data && event.data.action === 'CACHE_AUDIO') {
+    const { url } = event.data;
+    if (url) {
+      if (abortControllers.has(url)) {
+        abortControllers.get(url)?.abort();
+        abortControllers.delete(url);
+      }
+
+      const controller = new AbortController();
+      abortControllers.set(url, controller);
+
+      try {
+        const cache = await caches.open('quran-audio');
+        const response = await fetch(url, { signal: controller.signal });
+
+        if (!response.ok) {
+          event.ports[0]?.postMessage({ success: false, url, error: 'Network response was not ok' });
+          abortControllers.delete(url);
+          return;
+        }
+
+        const contentLength = response.headers.get('content-length');
+        const total = contentLength ? parseInt(contentLength, 10) : 0;
+        let loaded = 0;
+
+        const cloneForCache = response.clone();
+        const cachePromise = cache.put(url, cloneForCache);
+
+        const reader = response.body?.getReader();
+        if (reader) {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            loaded += value.length;
+            event.ports[0]?.postMessage({ progress: true, url, loaded, total });
+          }
+        }
+
+        await cachePromise;
+        abortControllers.delete(url);
+        event.ports[0]?.postMessage({ success: true, url, total, loaded: total });
+      } catch (error: any) {
+        abortControllers.delete(url);
+        if (error.name === 'AbortError') {
+          event.ports[0]?.postMessage({ success: false, url, aborted: true });
+        } else {
+          event.ports[0]?.postMessage({ success: false, url, error: error.message });
+        }
+      }
+    }
+  } else if (event.data && event.data.action === 'ABORT_AUDIO') {
+    const { url } = event.data;
+    if (url && abortControllers.has(url)) {
+      abortControllers.get(url)?.abort();
+      abortControllers.delete(url);
+      event.ports[0]?.postMessage({ success: true, url });
+    }
+  } else if (event.data && event.data.action === 'REMOVE_AUDIO') {
+    const { url } = event.data;
+    if (url) {
+      try {
+        const cache = await caches.open('quran-audio');
+        const deleted = await cache.delete(url);
+        event.ports[0]?.postMessage({ success: deleted, url });
+      } catch (error: any) {
+        event.ports[0]?.postMessage({ success: false, error: error.message });
+      }
+    }
+  } else if (event.data && event.data.action === 'CHECK_CACHED') {
+    const { url } = event.data;
+    if (url) {
+      try {
+        const cache = await caches.open('quran-audio');
+        const response = await cache.match(url);
+
+        let size = 0;
+        if (response) {
+          const sizeStr = response.headers.get('content-length');
+          if (sizeStr) size = parseInt(sizeStr, 10);
+          else {
+            const blob = await response.clone().blob();
+            size = blob.size;
+          }
+        }
+
+        event.ports[0]?.postMessage({
+          success: true,
+          isCached: !!response,
+          url,
+          size
+        });
+      } catch (error: any) {
+        event.ports[0]?.postMessage({ success: false, error: error.message });
+      }
+    }
+  }
+});


### PR DESCRIPTION
- Create DownloadMushafButton component to trigger and manage downloads.
- Add useMushafDownload hook to handle API requests, caching, and progress tracking.
- Update reciter-page to include the download button in the reciter menu.
- Enhance Service Worker (sw.ts) to handle audio caching, pausing, resuming, and size calculation.
- Add localization keys for the new download-related text.
- Update quran-audio cache maxEntries to accommodate a full Mushaf offline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added offline download capability for Quran audio with progress tracking.
  * Users can now pause, resume, and remove downloaded audio files.
  * Display of download status and available offline content.

* **Chores**
  * Updated localization strings to support the new offline feature.
  * Enhanced service worker cache configuration for improved offline support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->