### PR TITLE
fix: layout and RTL alignment for settings and switches

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -72,7 +72,7 @@ export default function SettingsPage() {
               return (
                 <li
                   key={source}
-                  className="text- flex items-center gap-3 rtl:flex-row-reverse"
+                  className="flex items-center gap-3"
                 >
                   <input
                     id={`source-${source}`}
@@ -100,7 +100,7 @@ export default function SettingsPage() {
           className="m-1 space-y-4 rounded p-4 text-start md:m-2 md:border md:border-gray-200 md:bg-white md:p-8 md:shadow-sm md:dark:border-gray-600 md:dark:bg-gray-800"
           dir={isRTL ? 'rtl' : 'ltr'}
         >
-          <h2 className="text-xl font-semibold text-slate-900">
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-300">
             <FormattedMessage
               id="settings.cacheManagement"
               defaultMessage="Offline downloads"

--- a/src/components/fullscreen-controller.tsx
+++ b/src/components/fullscreen-controller.tsx
@@ -32,9 +32,12 @@ export default function FullscreenController({
       {isFullscreen ? <ExitFullscreen /> : null}
       {isFullscreen ? null : <SettingsLink />}
       {isFullscreen ? null : (
-        <div className="fixed right-4 top-4 z-50 flex items-center gap-2">
-          <ThemeSwitcher />
+        <div 
+          className="fixed top-4 z-50 flex items-center gap-2"
+          style={{ left: '1rem', right: 'auto', direction: 'ltr' }}
+        >
           <LanguageSwitcher />
+          <ThemeSwitcher />
         </div>
       )}
       <div className="flex w-full flex-grow items-center justify-center">

--- a/src/components/settings-link.tsx
+++ b/src/components/settings-link.tsx
@@ -7,7 +7,8 @@ export default function SettingsLink() {
   return (
     <Link
       href="/settings"
-      className="fixed left-4 top-4 z-50 flex h-8 w-8 items-center justify-center rounded-full border border-gray-300 bg-white text-sm font-semibold text-gray-600 shadow-sm transition-all duration-200 hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus:ring-brand-CTA-blue-500 focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-100"
+      className="fixed top-4 z-50 flex h-8 w-8 items-center justify-center rounded-full border border-gray-300 bg-white text-sm font-semibold text-gray-600 shadow-sm transition-all duration-200 hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus:ring-brand-CTA-blue-500 focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-100"
+      style={{ right: '1rem', left: 'auto' }}
       aria-label="Settings"
     >
       <IoSettingsOutline className="size-5" />


### PR DESCRIPTION
### Description
This PR addresses layout and alignment inconsistencies when toggling between Arabic (RTL) and English (LTR) modes. It ensures that navigation elements maintain consistent visual positions across different interface orientations.

### Fixes
- **RTL Alignment in Settings**: Fixed the Reciter Sources section alignment to correctly respond to RTL layout. (Fixes #55)
- **UI Element Stickiness**: Locked the Language and Theme switches to the top-left and the Settings link to the top-right, preventing them from flipping when the language changes. (Fixes #56)

### Implementation details
- **[src/app/settings/page.tsx](src/app/settings/page.tsx)**: Applied standard RTL alignment to the Reciter Sources container.
- **[src/components/fullscreen-controller.tsx](src/components/fullscreen-controller.tsx)**: Added explicit `left: 1rem` and `direction: ltr` to the switch container to force a consistent Left-to-Right order and position (Left side).
- **[src/components/settings-link.tsx](src/components/settings-link.tsx)**: Added explicit `right: 1rem` to the settings icon to keep it fixed on the Right side.

### Visual Comparison

#### 1. Settings Alignment (#55)
| Before | After |
| :--- | :--- |
| ![Before Settings](https://github.com/user-attachments/assets/d902b2e2-ef85-4c3d-b940-9fc15adc50da) | ![After Settings](https://github.com/user-attachments/assets/90a9bf0e-d9da-4f72-b434-bde40141794a) |

#### 2. Switch Consistency (#56)
*Screenshots showing the corrected layout where switches and settings icons remain fixed regardless of language:*

![Layout Overview](https://github.com/user-attachments/assets/b2c26c5a-274d-4634-b646-0e662992d593)
![Detailed View](https://github.com/user-attachments/assets/0bd79fa3-5f00-41a9-a9d9-79c553a32880)