### PR TITLE
feat: sync Quran text with recitation playback

### DIFF
--- a/src/app/api/surah/[id]/route.ts
+++ b/src/app/api/surah/[id]/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// Surah text never changes, so cache for a very long time.
+export const revalidate = 31536000;
+
+const BASE_URL = 'https://api.alquran.cloud/v1';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const searchParams = request.nextUrl.searchParams;
+  const edition = searchParams.get('edition') || 'quran-uthmani';
+
+  if (!/^\d{1,3}$/.test(id) || Number(id) < 1 || Number(id) > 114) {
+    return NextResponse.json({ error: 'Invalid surah id' }, { status: 400 });
+  }
+
+  try {
+    const response = await fetch(`${BASE_URL}/surah/${id}/${edition}`, {
+      next: { revalidate },
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: 'Failed to fetch surah' },
+        { status: response.status }
+      );
+    }
+
+    const json = await response.json();
+
+    return NextResponse.json(json.data, {
+      headers: {
+        'Cache-Control':
+          'public, s-maxage=31536000, max-age=86400, stale-while-revalidate=604800, immutable',
+      },
+    });
+  } catch {
+    return NextResponse.json(
+      { error: 'Failed to fetch surah' },
+      { status: 502 }
+    );
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import './globals.css';
 
 import { Metadata } from 'next';
-import { Tajawal } from 'next/font/google';
+import { Amiri, Tajawal } from 'next/font/google';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 
 import { EnabledSourcesCookieSync } from '@/components/enabled-sources-cookie-sync';
@@ -38,6 +38,15 @@ const tajawal = Tajawal({
   preload: true,
 });
 
+// Amiri for the mushaf (Quran text) in reading mode.
+const amiri = Amiri({
+  weight: ['400', '700'],
+  subsets: ['arabic'],
+  style: ['normal'],
+  display: 'swap',
+  variable: '--font-amiri',
+});
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -48,7 +57,7 @@ export default function RootLayout({
       <IntlProviderWrapper>
         <HtmlWrapper>
           <body
-            className={`${tajawal.className} min-h-full bg-background antialiased`}
+            className={`${tajawal.className} ${amiri.variable} min-h-full bg-background antialiased`}
           >
             <main className="duration-350 relative flex min-h-dvh w-full flex-col items-center justify-center bg-background text-foreground transition-colors">
               <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">

--- a/src/components/player-controls.tsx
+++ b/src/components/player-controls.tsx
@@ -15,7 +15,7 @@ import Image from 'next/image';
 import React, { RefObject, useEffect, useRef, useState } from 'react';
 import { BiVolumeFull, BiVolumeMute } from 'react-icons/bi';
 import { BsFullscreen, BsFullscreenExit } from 'react-icons/bs';
-import { MdRepeatOne, MdSpeed } from 'react-icons/md';
+import { MdMenuBook, MdRepeatOne, MdSpeed } from 'react-icons/md';
 import { useIntl } from 'react-intl';
 
 import Tooltip from '@/components/tooltip';
@@ -25,6 +25,7 @@ import {
   fullscreenAtom,
   playbackModeAtom,
   playbackSpeedAtom,
+  readingModeAtom,
   showVisualizerAtom,
   volumeAtom,
 } from '@/jotai/atom';
@@ -68,6 +69,7 @@ export default function PlayerControls({
   const isFullscreen = useAtomValue(fullscreenAtom);
   const [playbackSpeed, setPlaybackSpeed] = useAtom(playbackSpeedAtom);
   const [playbackMode, setPlaybackMode] = useAtom(playbackModeAtom);
+  const [readingMode, setReadingMode] = useAtom(readingModeAtom);
 
   const moreMenuRef = useRef<HTMLDivElement>(null);
   const desktopSleepMenuRef = useRef<HTMLDivElement>(null);
@@ -225,6 +227,10 @@ export default function PlayerControls({
       defaultMessage: 'Volume control',
     }),
     more: formatMessage({ id: 'player.more', defaultMessage: 'More options' }),
+    readingMode: formatMessage({
+      id: 'reading.toggle',
+      defaultMessage: 'Reading mode',
+    }),
     sleepTimer: formatMessage({
       id: 'player.sleepTimer',
       defaultMessage: 'Sleep timer',
@@ -515,6 +521,21 @@ export default function PlayerControls({
 
             <button
               onClick={() => {
+                setReadingMode((previous) => !previous);
+                setShowMoreMenu(false);
+              }}
+              className={cn(
+                'flex items-center gap-2 rounded px-3 py-2 text-sm text-gray-800 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700',
+                readingMode &&
+                  'dark:text-brand-CTA-blue-400 text-brand-CTA-blue-600'
+              )}
+            >
+              <MdMenuBook size={16} />
+              <span>{messages.readingMode}</span>
+            </button>
+
+            <button
+              onClick={() => {
                 togglePlaybackSpeed();
                 setShowMoreMenu(false);
               }}
@@ -658,6 +679,21 @@ export default function PlayerControls({
             </div>
           )}
         </div>
+
+        <Tooltip content={messages.readingMode}>
+          <button
+            onClick={() => setReadingMode((previous) => !previous)}
+            className={cn(
+              'flex h-9 w-9 items-center justify-center rounded hover:bg-gray-200 dark:hover:bg-gray-700',
+              readingMode &&
+                'dark:text-brand-CTA-blue-400 bg-sky-100 text-brand-CTA-blue-600 dark:bg-sky-900/40'
+            )}
+            aria-label={messages.readingMode}
+            aria-pressed={readingMode}
+          >
+            <MdMenuBook size={ICON_SIZE} />
+          </button>
+        </Tooltip>
 
         {renderImageButton(
           playlistSVG,

--- a/src/components/player.tsx
+++ b/src/components/player.tsx
@@ -10,6 +10,7 @@ import {
   fullscreenAtom,
   playbackModeAtom,
   playbackSpeedAtom,
+  readingModeAtom,
   volumeAtom,
 } from '@/jotai/atom';
 import { Playlist } from '@/types';
@@ -18,6 +19,7 @@ import { cn } from '@/utils';
 import AudioBarsVisualizer from './audio-bars-visualizer';
 import PlayerControls from './player-controls';
 import Range from './range';
+import ReadingView from './reading-view';
 import TrackInfo from './track-info';
 
 const PlaylistDialog = dynamic(
@@ -37,6 +39,7 @@ type Props = {
 
 export default function Player({ playlist }: Props) {
   const isFullscreen = useAtomValue(fullscreenAtom);
+  const [readingMode] = useAtom(readingModeAtom);
   const [playbackMode] = useAtom(playbackModeAtom);
   const previousTrackRef = useRef<number | undefined>(undefined);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -112,6 +115,15 @@ export default function Player({ playlist }: Props) {
     if (!audioRef.current) return;
     isPlaying ? audioRef.current.pause() : audioRef.current.play();
     setIsPlaying(!isPlaying);
+  };
+
+  const handleAyahSelect = (seconds: number) => {
+    if (!audioRef.current) return;
+    audioRef.current.currentTime = seconds;
+    if (!isPlaying) {
+      void audioRef.current.play();
+      setIsPlaying(true);
+    }
   };
 
   const handleTimeUpdate = () => {
@@ -263,6 +275,17 @@ export default function Player({ playlist }: Props) {
                 currentTime={currentTime}
               />
             </>
+          )}
+
+          {readingMode && playlist[currentTrack]?.surahId && (
+            <ReadingView
+              key={playlist[currentTrack].surahId}
+              surahId={playlist[currentTrack].surahId}
+              currentTime={currentTime}
+              duration={duration}
+              isPlaying={isPlaying}
+              onAyahSelect={handleAyahSelect}
+            />
           )}
         </div>
       )}

--- a/src/components/reading-view.tsx
+++ b/src/components/reading-view.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useSetAtom } from 'jotai';
+import { useEffect, useMemo, useRef } from 'react';
+import { useIntl } from 'react-intl';
+
+import { SURAHS } from '@/constants';
+import { useAyahTracking } from '@/hooks/use-ayah-tracking';
+import { useSurahText } from '@/hooks/use-surah-text';
+import { currentAyahAtom } from '@/jotai/atom';
+import { cn, removeTashkeel } from '@/utils';
+
+// Bismillah rendered at the head of every surah except At-Tawbah (9).
+// Surah 1 already includes it as its first ayah.
+const BISMILLAH = 'بِسۡمِ ٱللَّهِ ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ';
+
+const ARABIC_INDIC_DIGITS: Record<string, string> = {
+  '0': '٠',
+  '1': '١',
+  '2': '٢',
+  '3': '٣',
+  '4': '٤',
+  '5': '٥',
+  '6': '٦',
+  '7': '٧',
+  '8': '٨',
+  '9': '٩',
+};
+
+const toArabicIndic = (value: number): string =>
+  String(value).replaceAll(
+    /\d/g,
+    (digit) => ARABIC_INDIC_DIGITS[digit] ?? digit
+  );
+
+type Props = {
+  surahId: string | null;
+  currentTime: number;
+  duration: number;
+  isPlaying: boolean;
+  onAyahSelect: (seconds: number) => void;
+};
+
+export default function ReadingView({
+  surahId,
+  currentTime,
+  duration,
+  isPlaying,
+  onAyahSelect,
+}: Props) {
+  const { surahText, loading, error } = useSurahText(surahId);
+  const { timestamps, currentAyahIndex } = useAyahTracking({
+    ayahs: surahText?.ayahs ?? [],
+    currentTime,
+    duration,
+  });
+
+  const setCurrentAyah = useSetAtom(currentAyahAtom);
+  const ayahReferences = useRef<Array<HTMLButtonElement | null>>([]);
+  const { locale, formatMessage } = useIntl();
+
+  useEffect(() => {
+    setCurrentAyah(currentAyahIndex);
+  }, [currentAyahIndex, setCurrentAyah]);
+
+  // Keep the highlighted ayah in view while following the recitation.
+  useEffect(() => {
+    if (currentAyahIndex === null) return;
+    ayahReferences.current[currentAyahIndex]?.scrollIntoView({
+      block: 'center',
+      behavior: isPlaying ? 'smooth' : 'auto',
+    });
+  }, [currentAyahIndex, isPlaying]);
+
+  const surahNumber = Number(surahId);
+  const surahMeta = useMemo(
+    () => SURAHS.find((surah) => surah.id === surahNumber),
+    [surahNumber]
+  );
+
+  const surahName = useMemo(() => {
+    if (!surahMeta) return '';
+    return locale === 'en'
+      ? surahMeta.englishName
+      : removeTashkeel(surahMeta.name);
+  }, [surahMeta, locale]);
+
+  const showBismillah =
+    surahNumber > 1 && surahNumber !== 9 && (surahText?.ayahs.length ?? 0) > 0;
+
+  if (loading) {
+    return (
+      <div className="mt-3 w-full max-w-xl animate-pulse space-y-2 rounded-md border border-gray-200 p-4 shadow-md dark:border-gray-200/50">
+        <div className="mx-auto h-4 w-32 rounded-full bg-gray-200 dark:bg-gray-700" />
+        <div className="h-16 rounded bg-gray-100 dark:bg-gray-800" />
+        <div className="h-16 rounded bg-gray-100 dark:bg-gray-800" />
+        <div className="h-16 rounded bg-gray-100 dark:bg-gray-800" />
+      </div>
+    );
+  }
+
+  if (error || !surahText || surahText.ayahs.length === 0) {
+    return (
+      <div className="mt-3 w-full max-w-xl rounded-md border border-red-200 bg-red-50 p-4 text-center text-sm text-red-600 dark:border-red-900 dark:bg-red-950/40 dark:text-red-400">
+        {error ??
+          formatMessage({
+            id: 'reading.noText',
+            defaultMessage: 'No text available for this surah.',
+          })}
+      </div>
+    );
+  }
+
+  const handleAyahClick = (index: number) => {
+    const start = timestamps[index]?.start;
+    if (typeof start === 'number') onAyahSelect(start);
+  };
+
+  return (
+    <div className="mt-3 w-full max-w-xl rounded-md border border-gray-200 bg-surface p-4 text-foreground shadow-md dark:border-gray-200/50">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h3 className="flex items-center gap-2 text-lg font-bold">
+          <span className="text-accent">{surahNumber}</span>
+          <span>{surahName}</span>
+        </h3>
+        <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+          {formatMessage({
+            id: 'reading.estimated',
+            defaultMessage: '~ Estimated timing',
+          })}
+        </span>
+      </div>
+
+      <div
+        dir="rtl"
+        className="max-h-[55vh] space-y-3 overflow-y-auto pe-1 text-right font-amiri"
+      >
+        {showBismillah && (
+          <div className="pt-1 text-center text-2xl leading-relaxed">
+            {BISMILLAH}
+          </div>
+        )}
+
+        {surahText.ayahs.map((ayah, index) => {
+          const isCurrent = currentAyahIndex === index;
+          return (
+            <button
+              key={ayah.numberInSurah}
+              ref={(element) => {
+                ayahReferences.current[index] = element;
+              }}
+              type="button"
+              onClick={() => handleAyahClick(index)}
+              className={cn(
+                'block w-full rounded-lg px-2 py-1 text-right text-start text-[1.35rem] leading-[2.2rem] transition-colors',
+                isCurrent
+                  ? 'bg-sky-100/90 ring-1 ring-sky-300 dark:bg-sky-900/40 dark:ring-sky-700'
+                  : 'hover:bg-gray-100 dark:hover:bg-gray-800/70'
+              )}
+            >
+              <span className="break-words">{ayah.text}</span>
+              <span className="ms-2 align-middle text-xl text-accent">
+                ﴿{toArabicIndic(ayah.numberInSurah)}﴾
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/use-ayah-tracking.ts
+++ b/src/hooks/use-ayah-tracking.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import {
+  type AyahTimestamp,
+  buildEstimatedTimestamps,
+  getAyahAtTime,
+} from '@/services/quran-text';
+import type { SurahAyahText } from '@/types';
+
+type UseAyahTrackingParams = {
+  ayahs: SurahAyahText[];
+  currentTime: number;
+  duration: number;
+};
+
+type UseAyahTrackingResult = {
+  /** Estimated start/end timestamps per ayah (seconds). */
+  timestamps: AyahTimestamp[];
+  /** Index of the ayah currently being recited, or null. */
+  currentAyahIndex: number | null;
+};
+
+/**
+ * Derives which ayah is playing based on the audio position.
+ *
+ * Uses estimated timestamps (proportional to ayah length) since the
+ * full-surah audio files from mp3quran/itqan don't carry timing data.
+ */
+export function useAyahTracking({
+  ayahs,
+  currentTime,
+  duration,
+}: UseAyahTrackingParams): UseAyahTrackingResult {
+  const timestamps = useMemo(
+    () => buildEstimatedTimestamps(ayahs, duration),
+    [ayahs, duration]
+  );
+
+  const currentAyahIndex = useMemo(
+    () => getAyahAtTime(timestamps, currentTime),
+    [timestamps, currentTime]
+  );
+
+  return { timestamps, currentAyahIndex };
+}

--- a/src/hooks/use-surah-text.ts
+++ b/src/hooks/use-surah-text.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { getSurahText } from '@/services/quran-text';
+import type { SurahText } from '@/types';
+
+type UseSurahTextResult = {
+  surahText: SurahText | null;
+  loading: boolean;
+  error: string | null;
+};
+
+export function useSurahText(
+  surahId: string | number | null | undefined
+): UseSurahTextResult {
+  const [surahText, setSurahText] = useState<SurahText | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (surahId === null || surahId === undefined || surahId === '') {
+      setSurahText(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let isMounted = true;
+
+    setLoading(true);
+    setError(null);
+
+    getSurahText(surahId)
+      .then((data) => {
+        if (!isMounted) return;
+        setSurahText(data);
+      })
+      .catch(() => {
+        if (!isMounted) return;
+        setError('Failed to load surah text.');
+      })
+      .finally(() => {
+        if (isMounted) setLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [surahId]);
+
+  return { surahText, loading, error };
+}

--- a/src/jotai/atom.ts
+++ b/src/jotai/atom.ts
@@ -1,3 +1,5 @@
+import { atom } from 'jotai';
+
 import { LinkSource, Reciter, Riwaya } from '@/types';
 
 import { createAtomWithStorage } from './create-atom-with-storage';
@@ -18,6 +20,11 @@ export const fullscreenAtom = createAtomWithStorage<boolean>(
   'fullscreen',
   false
 );
+export const readingModeAtom = createAtomWithStorage<boolean>(
+  'reading-mode',
+  false
+);
+export const currentAyahAtom = atom<number | null>(null);
 export const showVisualizerAtom = createAtomWithStorage<boolean>(
   'show-visualizer',
   true

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -127,6 +127,10 @@
   "reciterDialog.title": "اختر قارئًا",
   "player.cancelTimer": "إلغاء المؤقت",
 
+  "reading.toggle": "وضع القراءة",
+  "reading.estimated": "~ توقيت تقريبي",
+  "reading.noText": "لا يتوفر نص لهذه السورة.",
+
   "download.downloadAll": "تحميل جميع السور للاستماع دون إنترنت ({cached}/{total})",
   "download.downloading": "جاري التحميل… {completed}/{total}",
   "download.failed": "{count} فشل",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -127,6 +127,10 @@
   "reciterDialog.title": "Select a Reciter",
   "player.cancelTimer": "Cancel Timer",
 
+  "reading.toggle": "Reading mode",
+  "reading.estimated": "~ Estimated timing",
+  "reading.noText": "No text available for this surah.",
+
   "download.downloadAll": "Download all surahs for offline ({cached}/{total})",
   "download.downloading": "Downloading… {completed}/{total}",
   "download.failed": "{count} failed",

--- a/src/services/quran-text/index.ts
+++ b/src/services/quran-text/index.ts
@@ -1,0 +1,70 @@
+import type { SurahText } from '@/types';
+
+import { fetchSurahText } from './quran-text.adapter';
+
+export type { AyahEdition } from './reciter-mapping';
+export {
+  getAyahEditionForReciter,
+  VERSE_BY_VERSE_EDITIONS,
+} from './reciter-mapping';
+export {
+  ayahTextWeight,
+  type AyahTimestamp,
+  buildEstimatedTimestamps,
+  getAyahAtTime,
+} from './timestamps';
+
+const TEXT_CACHE_PREFIX = 'surah-text:';
+
+const readCache = (key: string): SurahText | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as SurahText) : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeCache = (key: string, data: SurahText): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(key, JSON.stringify(data));
+  } catch {
+    // Storage full or unavailable — ignore, the fetch still succeeded.
+  }
+};
+
+/**
+ * Fetches the text of a surah.
+ *
+ * - On the server: fetches alquran.cloud directly (used for SSR metadata).
+ * - On the client: reads from the localStorage cache first, then falls back
+ *   to the `/api/surah/{id}` proxy route and persists the result.
+ */
+export async function getSurahText(
+  surahId: string | number
+): Promise<SurahText> {
+  const id = String(surahId);
+  const cacheKey = `${TEXT_CACHE_PREFIX}${id}`;
+
+  const isServer = typeof window === 'undefined';
+
+  if (isServer) {
+    return fetchSurahText(Number(id));
+  }
+
+  const cached = readCache(cacheKey);
+  if (cached) return cached;
+
+  const response = await fetch(`/api/surah/${id}`, {
+    next: { revalidate: 31536000 },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch surah ${id}: ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as SurahText;
+  writeCache(cacheKey, data);
+  return data;
+}

--- a/src/services/quran-text/quran-text.adapter.ts
+++ b/src/services/quran-text/quran-text.adapter.ts
@@ -1,0 +1,28 @@
+import type { SurahText } from '@/types';
+
+const BASE_URL = 'https://api.alquran.cloud/v1';
+
+export const DEFAULT_TEXT_EDITION = 'quran-uthmani';
+
+export type TextEdition = 'quran-uthmani' | 'quran-simple';
+
+/**
+ * Fetches surah text directly from alquran.cloud (server-side only).
+ * The client should go through `getSurahText` which uses the proxied
+ * `/api/surah/{id}` route.
+ */
+export async function fetchSurahText(
+  surahId: number,
+  edition: TextEdition = DEFAULT_TEXT_EDITION
+): Promise<SurahText> {
+  const response = await fetch(`${BASE_URL}/surah/${surahId}/${edition}`, {
+    next: { revalidate: 31536000 },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch surah ${surahId}: ${response.statusText}`);
+  }
+
+  const json = await response.json();
+  return json.data as SurahText;
+}

--- a/src/services/quran-text/reciter-mapping.test.ts
+++ b/src/services/quran-text/reciter-mapping.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAyahEditionForReciter } from './reciter-mapping';
+
+describe('getAyahEditionForReciter', () => {
+  it('returns null for empty input', () => {
+    expect(getAyahEditionForReciter('')).toBeNull();
+    expect(getAyahEditionForReciter('   ')).toBeNull();
+  });
+
+  it('matches an exact normalized name', () => {
+    expect(getAyahEditionForReciter('مشاري راشد العفاسي')?.identifier).toBe(
+      'ar.alafasy'
+    );
+  });
+
+  it('matches despite tashkeel / alef variations', () => {
+    expect(
+      getAyahEditionForReciter('عَبْدُ البَاسِط عبد الصمد')?.identifier
+    ).toBe('ar.abdulbasitmurattal');
+  });
+
+  it('matches a name with a title prefix', () => {
+    expect(
+      getAyahEditionForReciter('الشيخ مشاري راشد العفاسي')?.identifier
+    ).toBe('ar.alafasy');
+  });
+
+  it('fuzzy-matches a close name variation', () => {
+    expect(getAyahEditionForReciter('مشاري العفاسي')?.identifier).toBe(
+      'ar.alafasy'
+    );
+  });
+
+  it('matches the mujawwad variants distinctly', () => {
+    expect(
+      getAyahEditionForReciter('محمد صديق المنشاوي (مجود)')?.identifier
+    ).toBe('ar.minshawimujawwad');
+  });
+
+  it('returns null for an unknown reciter', () => {
+    expect(getAyahEditionForReciter('فارس عباد')).toBeNull();
+  });
+});

--- a/src/services/quran-text/reciter-mapping.ts
+++ b/src/services/quran-text/reciter-mapping.ts
@@ -1,0 +1,148 @@
+import Fuse from 'fuse.js';
+
+import { normalizeArabicText } from '@/utils';
+
+export type AyahEdition = {
+  /** alquran.cloud edition identifier, e.g. `ar.alafasy`. */
+  identifier: string;
+  name: string;
+  englishName: string;
+};
+
+/**
+ * Reciters that have verse-by-verse audio on alquran.cloud. Used to switch
+ * from full-surah playback to precise per-ayah playback in reading mode.
+ */
+export const VERSE_BY_VERSE_EDITIONS: AyahEdition[] = [
+  {
+    identifier: 'ar.alafasy',
+    name: 'مشاري راشد العفاسي',
+    englishName: 'Alafasy',
+  },
+  {
+    identifier: 'ar.abdulbasitmurattal',
+    name: 'عبد الباسط عبد الصمد',
+    englishName: 'Abdul Basit (Murattal)',
+  },
+  {
+    identifier: 'ar.abdulbasitmujawwad',
+    name: 'عبد الباسط عبد الصمد (مجوّد)',
+    englishName: 'Abdul Basit (Mujawwad)',
+  },
+  {
+    identifier: 'ar.husary',
+    name: 'محمود خليل الحصري',
+    englishName: 'Husary (Murattal)',
+  },
+  {
+    identifier: 'ar.husarymujawwad',
+    name: 'محمود خليل الحصري (مجوّد)',
+    englishName: 'Husary (Mujawwad)',
+  },
+  {
+    identifier: 'ar.minshawi',
+    name: 'محمد صديق المنشاوي',
+    englishName: 'Minshawi (Murattal)',
+  },
+  {
+    identifier: 'ar.minshawimujawwad',
+    name: 'محمد صديق المنشاوي (مجوّد)',
+    englishName: 'Minshawi (Mujawwad)',
+  },
+  {
+    identifier: 'ar.shaatree',
+    name: 'أبو بكر الشاطري',
+    englishName: 'Shatree',
+  },
+  {
+    identifier: 'ar.mahermuaiqly',
+    name: 'ماهر المعيقلي',
+    englishName: 'Maher Al Muaiqly',
+  },
+  {
+    identifier: 'ar.sudais',
+    name: 'عبد الرحمن السديس',
+    englishName: 'Abdurrahmaan As-Sudais',
+  },
+  {
+    identifier: 'ar.saoodshuraym',
+    name: 'سعود الشريم',
+    englishName: 'Saood bin Ibraaheem Shuraym',
+  },
+  {
+    identifier: 'ar.aymanswoaid',
+    name: 'أيمن سويد',
+    englishName: 'Ayman Sowaid',
+  },
+  {
+    identifier: 'ar.ibrahimakhbar',
+    name: 'إبراهيم الأخضر',
+    englishName: 'Ibraheem Akhder',
+  },
+  {
+    identifier: 'ar.muhammadayyoub',
+    name: 'محمد أيوب',
+    englishName: 'Muhammad Ayyoub',
+  },
+  {
+    identifier: 'ar.hanirifai',
+    name: 'هاني الرفاعي',
+    englishName: 'Hani Rifai',
+  },
+  {
+    identifier: 'ar.saadghamdi',
+    name: 'سعد الغامدي',
+    englishName: 'Saad Al Ghamdi',
+  },
+];
+
+const EXACT_MAP = new Map<string, AyahEdition>(
+  VERSE_BY_VERSE_EDITIONS.map((edition) => [
+    normalizeArabicText(edition.name),
+    edition,
+  ])
+);
+
+let fuseInstance: Fuse<AyahEdition> | null = null;
+
+const getFuse = (): Fuse<AyahEdition> => {
+  if (fuseInstance) return fuseInstance;
+  fuseInstance = new Fuse(VERSE_BY_VERSE_EDITIONS, {
+    keys: ['name', 'englishName'],
+    threshold: 0.4,
+    distance: 200,
+    minMatchCharLength: 2,
+    ignoreLocation: true,
+    isCaseSensitive: false,
+    shouldSort: true,
+  });
+  return fuseInstance;
+};
+
+/**
+ * Resolves a reciter name to the alquran.cloud verse-by-verse edition that
+ * matches it, or `null` when there is no reliable match.
+ *
+ * Matching strategy:
+ * 1. Exact normalized match against known edition names.
+ * 2. Containment match (handles prefixes/suffixes like "الشيخ ...").
+ * 3. Fuzzy match (handles typos and variations) via Fuse.js.
+ */
+export function getAyahEditionForReciter(name: string): AyahEdition | null {
+  if (!name || name.trim() === '') return null;
+
+  const normalized = normalizeArabicText(name);
+
+  const exact = EXACT_MAP.get(normalized);
+  if (exact) return exact;
+
+  for (const edition of VERSE_BY_VERSE_EDITIONS) {
+    const editionName = normalizeArabicText(edition.name);
+    if (editionName.includes(normalized) || normalized.includes(editionName)) {
+      return edition;
+    }
+  }
+
+  const results = getFuse().search(name);
+  return results[0]?.item ?? null;
+}

--- a/src/services/quran-text/timestamps.test.ts
+++ b/src/services/quran-text/timestamps.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SurahAyahText } from '@/types';
+
+import {
+  ayahTextWeight,
+  buildEstimatedTimestamps,
+  getAyahAtTime,
+} from './timestamps';
+
+const makeAyahs = (texts: string[]): SurahAyahText[] =>
+  texts.map((text, index) => ({ numberInSurah: index + 1, text }));
+
+// ─────────────────────────────────────────
+// ayahTextWeight
+// ─────────────────────────────────────────
+
+describe('ayahTextWeight', () => {
+  it('counts words in a verse', () => {
+    expect(ayahTextWeight('بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ')).toBe(4);
+  });
+
+  it('collapses multiple whitespace', () => {
+    expect(ayahTextWeight('  أَلْحَمْدُ  لِلَّهِ  ')).toBe(2);
+  });
+
+  it('never returns less than one', () => {
+    expect(ayahTextWeight('')).toBe(1);
+    expect(ayahTextWeight('   ')).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────
+// buildEstimatedTimestamps
+// ─────────────────────────────────────────
+
+describe('buildEstimatedTimestamps', () => {
+  it('returns zero timestamps for an empty list', () => {
+    expect(buildEstimatedTimestamps([], 100)).toEqual([]);
+  });
+
+  it('returns zeros when duration is not finite or <= 0', () => {
+    const ayahs = makeAyahs(['كلمة', 'كلمة']);
+    expect(buildEstimatedTimestamps(ayahs, 0)).toEqual([
+      { start: 0, end: 0 },
+      { start: 0, end: 0 },
+    ]);
+    expect(buildEstimatedTimestamps(ayahs, Number.NaN)).toEqual([
+      { start: 0, end: 0 },
+      { start: 0, end: 0 },
+    ]);
+  });
+
+  it('starts at 0 and the final end equals the duration', () => {
+    const ayahs = makeAyahs(['واحد', 'اثنان ثلاثة']);
+    const timestamps = buildEstimatedTimestamps(ayahs, 90);
+    expect(timestamps[0].start).toBe(0);
+    expect(timestamps.at(-1)?.end).toBe(90);
+  });
+
+  it('weights longer ayahs with more time', () => {
+    const ayahs = makeAyahs(['واحد', 'اثنان ثلاثة أربعة خمسة']);
+    const timestamps = buildEstimatedTimestamps(ayahs, 60);
+    const firstSpan = timestamps[0].end - timestamps[0].start;
+    const secondSpan = timestamps[1].end - timestamps[1].start;
+    expect(secondSpan).toBeGreaterThan(firstSpan);
+  });
+
+  it('is contiguous (no gaps or overlaps)', () => {
+    const ayahs = makeAyahs(['واحد', 'اثنان', 'ثلاثة أربعة خمسة', 'ستة']);
+    const timestamps = buildEstimatedTimestamps(ayahs, 120);
+    for (let index = 1; index < timestamps.length; index++) {
+      expect(timestamps[index].start).toBeCloseTo(timestamps[index - 1].end, 6);
+    }
+  });
+});
+
+// ─────────────────────────────────────────
+// getAyahAtTime
+// ─────────────────────────────────────────
+
+const SAMPLE = buildEstimatedTimestamps(
+  makeAyahs(['واحد', 'اثنان', 'ثلاثة أربعة خمسة', 'ستة سبعة']),
+  120
+);
+
+describe('getAyahAtTime', () => {
+  it('returns null for empty timestamps', () => {
+    expect(getAyahAtTime([], 5)).toBeNull();
+  });
+
+  it('returns null for negative time', () => {
+    expect(getAyahAtTime(SAMPLE, -1)).toBeNull();
+  });
+
+  it('finds the first ayah at the very start', () => {
+    expect(getAyahAtTime(SAMPLE, 0)).toBe(0);
+  });
+
+  it('finds the correct ayah for a mid-range time', () => {
+    const mid = SAMPLE[2].start + 1;
+    expect(getAyahAtTime(SAMPLE, mid)).toBe(2);
+  });
+
+  it('returns the last ayah when time is past the end', () => {
+    expect(getAyahAtTime(SAMPLE, 999)).toBe(SAMPLE.length - 1);
+  });
+
+  it('treats the end boundary as the next ayah (half-open intervals)', () => {
+    const boundary = SAMPLE[1].end;
+    expect(getAyahAtTime(SAMPLE, boundary)).toBe(2);
+  });
+});

--- a/src/services/quran-text/timestamps.ts
+++ b/src/services/quran-text/timestamps.ts
@@ -1,0 +1,90 @@
+import type { SurahAyahText } from '@/types';
+
+export type AyahTimestamp = {
+  /** Start of the ayah in seconds (inclusive). */
+  start: number;
+  /** End of the ayah in seconds (exclusive). */
+  end: number;
+};
+
+/**
+ * Rough textual weight used to distribute the surah's total duration
+ * across ayahs. Longer ayahs (more words) take proportionally longer to
+ * recite, so word count is a reasonable estimator.
+ */
+export const ayahTextWeight = (text: string): number => {
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  return Math.max(1, words);
+};
+
+/**
+ * Builds estimated per-ayah timestamps by distributing `duration` across
+ * ayahs proportionally to their word counts.
+ *
+ * These are approximations — actual reciters pause between ayahs and vary
+ * their pace — but they're good enough to highlight while listening and to
+ * jump between ayahs. Used as a fallback when no precise timing data exists.
+ *
+ * @returns An array aligned with `ayahs` where `result[i]` spans ayah `i`.
+ */
+export function buildEstimatedTimestamps(
+  ayahs: SurahAyahText[],
+  duration: number
+): AyahTimestamp[] {
+  if (ayahs.length === 0 || !Number.isFinite(duration) || duration <= 0) {
+    return ayahs.map(() => ({ start: 0, end: 0 }));
+  }
+
+  const weights = ayahs.map((ayah) => ayahTextWeight(ayah.text));
+  const totalWeight = weights.reduce((sum, weight) => sum + weight, 0);
+  if (totalWeight <= 0) {
+    return ayahs.map(() => ({ start: 0, end: 0 }));
+  }
+
+  const timestamps: AyahTimestamp[] = [];
+  let cursor = 0;
+
+  for (let index = 0; index < ayahs.length; index++) {
+    const start = cursor;
+    cursor += (duration * weights[index]) / totalWeight;
+    timestamps.push({ start, end: cursor });
+  }
+
+  // Clamp the final boundary to the actual duration to avoid drift.
+  timestamps[timestamps.length - 1].end = duration;
+
+  return timestamps;
+}
+
+/**
+ * Finds the index of the ayah being recited at `time` (seconds) using
+ * binary search. Returns `null` when there are no timestamps or the time
+ * is outside the range.
+ */
+export function getAyahAtTime(
+  timestamps: AyahTimestamp[],
+  time: number
+): number | null {
+  if (timestamps.length === 0 || !Number.isFinite(time) || time < 0) {
+    return null;
+  }
+
+  let low = 0;
+  let high = timestamps.length - 1;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const { start, end } = timestamps[mid];
+
+    if (time >= start && time < end) return mid;
+    if (time < start) high = mid - 1;
+    else low = mid + 1;
+  }
+
+  // Time past the last ayah's end — return the last ayah.
+  return timestamps.length - 1;
+}
+
+/** Converts a surah's ayahs into plain texts for timestamp building. */
+export const ayahsToTexts = (ayahs: SurahAyahText[]): string[] =>
+  ayahs.map((ayah) => ayah.text);

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -73,10 +73,13 @@ self.addEventListener('fetch', (event) => {
   }
 });
 
-// API caching for reciters list
+// API caching for reciters list + surah text
 const apiCache = {
   matcher: ({ url }: { url: URL }) => {
-    return url.pathname.startsWith('/api/reciters');
+    return (
+      url.pathname.startsWith('/api/reciters') ||
+      url.pathname.startsWith('/api/surah')
+    );
   },
   handler: new CacheFirst({
     cacheName: 'api-reciters',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,4 +3,5 @@ export * from './playlist';
 export * from './reciter';
 export * from './riwaya';
 export * from './surah';
+export * from './surah-text';
 export * from './track-type';

--- a/src/types/surah-text.ts
+++ b/src/types/surah-text.ts
@@ -1,0 +1,13 @@
+export type SurahAyahText = {
+  numberInSurah: number;
+  text: string;
+};
+
+export type SurahText = {
+  number: number;
+  name: string;
+  englishName: string;
+  englishNameTranslation: string;
+  numberOfAyahs: number;
+  ayahs: SurahAyahText[];
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -36,6 +36,9 @@ const config: Config = {
         'brand-warning': '#FFA800',
         'brand-danger': '#FF4B4B',
       },
+      fontFamily: {
+        amiri: ['var(--font-amiri)', 'serif'],
+      },
     },
     keyframes: {
       slideIn: {


### PR DESCRIPTION
## Description

Synchronize the Quran text with the recitation playback so the displayed text follows the currently recited verse/segment. This improves the reading experience by helping users visually follow along with the recitation.

## Type of change

* [ ] Bug fix (non-breaking)
* [x] New feature (non-breaking)
* [ ] Breaking change
* [ ] Documentation update
* [ ] Chore / refactor / test (no user-facing change)

## Changes

* Synchronize the displayed Quran text with recitation playback
* Highlight the currently recited text during playback
* Keep the active text synchronized when playback progresses
* Maintain synchronization when pausing and resuming playback
* Update the active text when navigating or seeking through the recitation

## Testing

* [ ] `yarn format:check`
* [ ] `yarn lint`
* [ ] `yarn type-check`
* [ ] `yarn test:coverage`
* [ ] `yarn build`
* [ ] Manual QA on `yarn dev` (route(s) exercised: <!-- add the route you tested -->)

## Screenshots

<!-- Add screenshots or a short screen recording showing the text following the recitation. -->

## Checklist

* [x] Branched from the default base (`develop`)
* [ ] My code follows the style guidelines in `eslint.config.mjs` and
  `.prettierrc.mjs`
* [ ] I have performed a self-review of the diff
* [ ] I have commented code only where the intent is non-obvious
* [ ] I have updated docs / `CHANGELOG.md` where appropriate
* [ ] I have added or updated tests for new behavior
* [ ] If AI-assisted, I have re-read the diff and verified each change
  manually
* [ ] No new warnings from `yarn lint` or `yarn build`
* [ ] Related issue linked (`Fixes #` or `Refs #`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reading mode that displays surah text alongside audio playback.
  - Highlights the currently recited ayah and automatically scrolls it into view.
  - Allows selecting an ayah to jump playback directly to it.
  - Added Arabic and English labels for reading mode and related states.
  - Added improved Quran text rendering with the Amiri font.
- **Improvements**
  - Surah text now loads with caching and clearer loading, empty, and error states.
  - Added support for matching reciters to verse-by-verse audio editions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->