### PR TITLE
 feat(reciters): add quran.foundation as a new provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ FEED_BACK_PASSWORD=___
 FEED_BACK_SERVICE=___
 FEED_BACK_HOST=___
 FEED_BACK_PORT=___
+
+# Quran Foundation provider: OAuth2 client credentials (server-only; never commit the secret).
+QURAN_FOUNDATION_CLIENT_ID=___
+QURAN_FOUNDATION_CLIENT_SECRET=___

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [0.3.0-athar]
 
+### Features
+
+- feat(reciters): add quran.foundation as a new audio provider
+
 ### Fixes
 
 - fix: correct privacy page content

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -11,6 +11,10 @@ import { LinkSource } from '@/types';
 const AVAILABLE_SOURCES: { source: LinkSource; id: string }[] = [
   { source: LinkSource.MP3QURAN, id: 'settings.source.mp3quran' },
   { source: LinkSource.ITQAN, id: 'settings.source.itqan' },
+  {
+    source: LinkSource.QURAN_FOUNDATION,
+    id: 'settings.source.quranfoundation',
+  },
 ];
 
 export default function SettingsPage() {

--- a/src/components/reciter-card.tsx
+++ b/src/components/reciter-card.tsx
@@ -14,6 +14,7 @@ import { useShareReciter } from '@/utils/share';
 const SOURCE_LABEL_IDS: Partial<Record<LinkSource, string>> = {
   [LinkSource.MP3QURAN]: 'settings.source.mp3quran',
   [LinkSource.ITQAN]: 'settings.source.itqan',
+  [LinkSource.QURAN_FOUNDATION]: 'settings.source.quranfoundation',
 };
 
 type Props = {

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -17,6 +17,7 @@
   "settings.deselectAll": "إلغاء تفعيل الكل",
   "settings.source.mp3quran": "MP3 القرآن",
   "settings.source.itqan": "إتقان",
+  "settings.source.quranfoundation": "مؤسسة القرآن",
   "settings.enableSource": "قم بتفعيل مصدر واحد على الأقل من الإعدادات.",
   "reciter.select": "اختر القارئ",
   "favorites": "المفضلة",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -17,6 +17,7 @@
   "settings.deselectAll": "Deselect all",
   "settings.source.mp3quran": "MP3 Quran",
   "settings.source.itqan": "Itqan",
+  "settings.source.quranfoundation": "Quran Foundation",
   "settings.enableSource": "Enable at least one source in Settings.",
   "reciter.select": "Select A Reciter",
   "favorites": "favorites",

--- a/src/services/reciters/index.test.ts
+++ b/src/services/reciters/index.test.ts
@@ -16,13 +16,22 @@ vi.mock('./itqan.adapter', () => ({
   ItqanAdapter: { source: LinkSource.ITQAN, getReciters: vi.fn() },
 }));
 
+vi.mock('./quranfoundation.adapter', () => ({
+  QuranFoundationAdapter: {
+    source: LinkSource.QURAN_FOUNDATION,
+    getReciters: vi.fn(),
+  },
+}));
+
 const { getAllRecitersFromAdapters, parseEnabledSources } =
   await import('./index');
 const { Mp3QuranAdapter } = await import('./mp3quran.adapter');
 const { ItqanAdapter } = await import('./itqan.adapter');
+const { QuranFoundationAdapter } = await import('./quranfoundation.adapter');
 
 const mp3Mock = vi.mocked(Mp3QuranAdapter.getReciters);
 const itqanMock = vi.mocked(ItqanAdapter.getReciters);
+const quranFoundationMock = vi.mocked(QuranFoundationAdapter.getReciters);
 
 // ─────────────────────────────────────────────────────
 // Fixtures
@@ -48,6 +57,10 @@ const makeReciter = (id: string, source: LinkSource): Reciter => ({
 
 const mp3Reciter = makeReciter(`${LinkSource.MP3QURAN}-1`, LinkSource.MP3QURAN);
 const itqanReciter = makeReciter(`${LinkSource.ITQAN}-10`, LinkSource.ITQAN);
+const quranFoundationReciter = makeReciter(
+  `${LinkSource.QURAN_FOUNDATION}-7`,
+  LinkSource.QURAN_FOUNDATION
+);
 
 // ─────────────────────────────────────────────────────
 // Tests
@@ -61,37 +74,44 @@ describe('getAllRecitersFromAdapters', () => {
   it('returns combined results from all adapters', async () => {
     mp3Mock.mockResolvedValue([mp3Reciter]);
     itqanMock.mockResolvedValue([itqanReciter]);
+    quranFoundationMock.mockResolvedValue([quranFoundationReciter]);
 
     const result = await getAllRecitersFromAdapters('ar');
 
-    expect(result).toHaveLength(2);
+    expect(result).toHaveLength(3);
     expect(result).toContainEqual(mp3Reciter);
     expect(result).toContainEqual(itqanReciter);
+    expect(result).toContainEqual(quranFoundationReciter);
   });
 
   it('passes the lang argument to each adapter', async () => {
     mp3Mock.mockResolvedValue([]);
     itqanMock.mockResolvedValue([]);
+    quranFoundationMock.mockResolvedValue([]);
 
     await getAllRecitersFromAdapters('en');
 
     expect(mp3Mock).toHaveBeenCalledWith('en');
     expect(itqanMock).toHaveBeenCalledWith('en');
+    expect(quranFoundationMock).toHaveBeenCalledWith('en');
   });
 
   it('defaults lang to "ar" when not provided', async () => {
     mp3Mock.mockResolvedValue([]);
     itqanMock.mockResolvedValue([]);
+    quranFoundationMock.mockResolvedValue([]);
 
     await getAllRecitersFromAdapters();
 
     expect(mp3Mock).toHaveBeenCalledWith('ar');
     expect(itqanMock).toHaveBeenCalledWith('ar');
+    expect(quranFoundationMock).toHaveBeenCalledWith('ar');
   });
 
   it('still returns results from a working adapter when one adapter fails', async () => {
     mp3Mock.mockRejectedValue(new Error('mp3quran down'));
     itqanMock.mockResolvedValue([itqanReciter]);
+    quranFoundationMock.mockResolvedValue([]);
 
     const result = await getAllRecitersFromAdapters('ar');
 
@@ -102,6 +122,7 @@ describe('getAllRecitersFromAdapters', () => {
   it('returns an empty array when all adapters fail', async () => {
     mp3Mock.mockRejectedValue(new Error('mp3quran down'));
     itqanMock.mockRejectedValue(new Error('itqan down'));
+    quranFoundationMock.mockRejectedValue(new Error('quran.foundation down'));
 
     const result = await getAllRecitersFromAdapters('ar');
 
@@ -111,35 +132,41 @@ describe('getAllRecitersFromAdapters', () => {
   it('returns an empty array when all adapters return empty lists', async () => {
     mp3Mock.mockResolvedValue([]);
     itqanMock.mockResolvedValue([]);
+    quranFoundationMock.mockResolvedValue([]);
 
     const result = await getAllRecitersFromAdapters('ar');
 
     expect(result).toEqual([]);
   });
 
-  it('calls all adapters in parallel (both called regardless of each other)', async () => {
+  it('calls all adapters in parallel (all called regardless of each other)', async () => {
     mp3Mock.mockResolvedValue([mp3Reciter]);
     itqanMock.mockResolvedValue([itqanReciter]);
+    quranFoundationMock.mockResolvedValue([quranFoundationReciter]);
 
     await getAllRecitersFromAdapters('ar');
 
     expect(mp3Mock).toHaveBeenCalledTimes(1);
     expect(itqanMock).toHaveBeenCalledTimes(1);
+    expect(quranFoundationMock).toHaveBeenCalledTimes(1);
   });
 
-  it('preserves the order: mp3quran results before itqan results', async () => {
+  it('preserves registration order: mp3quran, itqan, quran.foundation', async () => {
     mp3Mock.mockResolvedValue([mp3Reciter]);
     itqanMock.mockResolvedValue([itqanReciter]);
+    quranFoundationMock.mockResolvedValue([quranFoundationReciter]);
 
     const result = await getAllRecitersFromAdapters('ar');
 
     expect(result[0].source).toBe(LinkSource.MP3QURAN);
     expect(result[1].source).toBe(LinkSource.ITQAN);
+    expect(result[2].source).toBe(LinkSource.QURAN_FOUNDATION);
   });
 
   it('when enabledSources provided, only fetches from those adapters', async () => {
     mp3Mock.mockResolvedValue([mp3Reciter]);
     itqanMock.mockResolvedValue([itqanReciter]);
+    quranFoundationMock.mockResolvedValue([quranFoundationReciter]);
 
     const result = await getAllRecitersFromAdapters('ar', [
       LinkSource.MP3QURAN,
@@ -149,6 +176,7 @@ describe('getAllRecitersFromAdapters', () => {
     expect(result[0]).toEqual(mp3Reciter);
     expect(mp3Mock).toHaveBeenCalledWith('ar');
     expect(itqanMock).not.toHaveBeenCalled();
+    expect(quranFoundationMock).not.toHaveBeenCalled();
   });
 });
 
@@ -170,6 +198,13 @@ describe('parseEnabledSources', () => {
     expect(parseEnabledSources('mp3quran.net,invalid,itqan.dev')).toEqual([
       LinkSource.MP3QURAN,
       LinkSource.ITQAN,
+    ]);
+  });
+
+  it('parses quran.foundation as a valid source', () => {
+    expect(parseEnabledSources('mp3quran.net,quran.foundation')).toEqual([
+      LinkSource.MP3QURAN,
+      LinkSource.QURAN_FOUNDATION,
     ]);
   });
 });

--- a/src/services/reciters/index.ts
+++ b/src/services/reciters/index.ts
@@ -3,9 +3,14 @@ import { LinkSource } from '@/types';
 
 import { ItqanAdapter } from './itqan.adapter';
 import { Mp3QuranAdapter } from './mp3quran.adapter';
+import { QuranFoundationAdapter } from './quranfoundation.adapter';
 import type { ReciterSource } from './reciter-source';
 
-const adapters: ReciterSource[] = [Mp3QuranAdapter, ItqanAdapter];
+const adapters: ReciterSource[] = [
+  Mp3QuranAdapter,
+  ItqanAdapter,
+  QuranFoundationAdapter,
+];
 
 const VALID_SOURCES = new Set<string>(Object.values(LinkSource));
 
@@ -56,4 +61,5 @@ export async function getAllRecitersFromAdapters(
 
 export { ItqanAdapter } from './itqan.adapter';
 export { Mp3QuranAdapter } from './mp3quran.adapter';
+export { QuranFoundationAdapter } from './quranfoundation.adapter';
 export type { ReciterSource } from './reciter-source';

--- a/src/services/reciters/quranfoundation.adapter.test.ts
+++ b/src/services/reciters/quranfoundation.adapter.test.ts
@@ -1,0 +1,388 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LinkSource, Riwaya } from '@/types';
+
+import {
+  QuranFoundationAdapter,
+  resetQuranFoundationCache,
+} from './quranfoundation.adapter';
+import type {
+  QuranFoundationChapterAudioResponse,
+  QuranFoundationChapterRecitersResponse,
+} from './quranfoundation.types';
+
+// Fixtures (mirror the live quran.foundation v4-aligned API)
+
+const makeChapterRecitersResponse =
+  (): QuranFoundationChapterRecitersResponse => ({
+    reciters: [
+      {
+        id: 7,
+        name: 'Mishari Rashid al-`Afasy',
+        style: {
+          name: 'Murattal',
+          translated_name: { name: 'Murattal', language_name: 'english' },
+        },
+        qirat: { name: 'Hafs', language_name: 'english' },
+        translated_name: {
+          name: 'Mishari Rashid al-`Afasy',
+          language_name: 'english',
+        },
+      },
+    ],
+  });
+
+const makeChapterAudioResponse = (): QuranFoundationChapterAudioResponse => ({
+  audio_files: [
+    {
+      id: 1001,
+      chapter_id: 2,
+      file_size: 2048.0,
+      format: 'mp3',
+      audio_url:
+        'https://download.quranicaudio.com/qdc/mishari_rashid_alafasy/murattal/2.mp3',
+    },
+    {
+      id: 1000,
+      chapter_id: 1,
+      file_size: 371.65,
+      format: 'mp3',
+      audio_url:
+        'https://download.quranicaudio.com/qdc/mishari_rashid_alafasy/murattal/1.mp3',
+    },
+    {
+      id: 1002,
+      chapter_id: 3,
+      file_size: 110_221_440.0,
+      format: 'mp3',
+      audio_url:
+        'https://download.quranicaudio.com/qdc/mishari_rashid_alafasy/murattal/3.mp3',
+    },
+  ],
+});
+
+const makeFetchResponse = (data: unknown, ok = true, status = 200) =>
+  Promise.resolve({
+    ok,
+    status,
+    json: () => Promise.resolve(data),
+  } as Response);
+
+// Tests
+
+describe('QuranFoundationAdapter', () => {
+  beforeEach(() => {
+    vi.stubEnv('QURAN_FOUNDATION_CLIENT_ID', 'test-client-id');
+    vi.stubEnv('QURAN_FOUNDATION_CLIENT_SECRET', 'test-client-secret');
+    // Disable request pacing so unit tests run fast.
+    vi.stubEnv('QURAN_FOUNDATION_RATE_LIMIT_MS', '0');
+    resetQuranFoundationCache();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (url.includes('chapter_recitations')) {
+          return makeFetchResponse(makeChapterAudioResponse());
+        }
+        if (url.includes('chapter_reciters')) {
+          return makeFetchResponse(makeChapterRecitersResponse());
+        }
+        // token endpoint
+        return makeFetchResponse({
+          access_token: 'test-access-token',
+          expires_in: 3600,
+          scope: 'content',
+        });
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  describe('source', () => {
+    it('is LinkSource.QURAN_FOUNDATION', () => {
+      expect(QuranFoundationAdapter.source).toBe(LinkSource.QURAN_FOUNDATION);
+    });
+  });
+
+  describe('getReciters', () => {
+    it('throws when client credentials are not configured', async () => {
+      vi.stubEnv('QURAN_FOUNDATION_CLIENT_ID', '');
+      await expect(QuranFoundationAdapter.getReciters('ar')).rejects.toThrow(
+        'QURAN_FOUNDATION_CLIENT_ID'
+      );
+    });
+
+    it('exchanges client credentials for an access token first', async () => {
+      await QuranFoundationAdapter.getReciters('ar');
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/oauth2/token'),
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/x-www-form-urlencoded',
+          }),
+        })
+      );
+    });
+
+    it('reuses a cached token on the next invocation', async () => {
+      await QuranFoundationAdapter.getReciters('ar');
+      await QuranFoundationAdapter.getReciters('en');
+      const tokenCalls = vi
+        .mocked(fetch)
+        .mock.calls.filter(([url]) => String(url).includes('/oauth2/token'));
+      expect(tokenCalls).toHaveLength(1);
+    });
+
+    it('sends x-auth-token and x-client-id on content requests', async () => {
+      await QuranFoundationAdapter.getReciters('ar');
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('chapter_reciters'),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'x-auth-token': 'test-access-token',
+            'x-client-id': 'test-client-id',
+          }),
+        })
+      );
+    });
+
+    it('fetches chapter audio for each reciter', async () => {
+      await QuranFoundationAdapter.getReciters('ar');
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('chapter_recitations/7'),
+        expect.anything()
+      );
+    });
+
+    it('returns one Reciter per chapter reciter', async () => {
+      const reciters = await QuranFoundationAdapter.getReciters('ar');
+      expect(reciters).toHaveLength(1);
+    });
+
+    it('builds a source-prefixed string ID from the reciter id', async () => {
+      const [reciter] = await QuranFoundationAdapter.getReciters('ar');
+      expect(reciter.id).toBe(`${LinkSource.QURAN_FOUNDATION}-7`);
+    });
+
+    it('sets source to LinkSource.QURAN_FOUNDATION', async () => {
+      const [reciter] = await QuranFoundationAdapter.getReciters('ar');
+      expect(reciter.source).toBe(LinkSource.QURAN_FOUNDATION);
+    });
+
+    it('maps the reciter name from translated_name', async () => {
+      const [reciter] = await QuranFoundationAdapter.getReciters('ar');
+      expect(reciter.name).toBe('Mishari Rashid al-`Afasy');
+    });
+
+    it('maps moshaf id to the reciter id string', async () => {
+      const [reciter] = await QuranFoundationAdapter.getReciters('ar');
+      expect(reciter.moshaf.id).toBe('7');
+    });
+
+    it('resolves riwaya from qirat.name', async () => {
+      const [reciter] = await QuranFoundationAdapter.getReciters('ar');
+      expect(reciter.moshaf.riwaya).toBe(Riwaya.Hafs);
+    });
+
+    it('defaults riwaya to Hafs when qirat is missing', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation((url: string) => {
+          if (url.includes('chapter_recitations')) {
+            return makeFetchResponse(makeChapterAudioResponse());
+          }
+          if (url.includes('chapter_reciters')) {
+            return makeFetchResponse({
+              reciters: [
+                {
+                  id: 7,
+                  name: 'Some Reciter',
+                  translated_name: {
+                    name: 'Some Reciter',
+                    language_name: 'english',
+                  },
+                },
+              ],
+            });
+          }
+          return makeFetchResponse({ access_token: 't', expires_in: 3600 });
+        })
+      );
+      const [reciter] = await QuranFoundationAdapter.getReciters('ar');
+      expect(reciter.moshaf.riwaya).toBe(Riwaya.Hafs);
+    });
+
+    it('sorts and builds a playlist from audio_files', async () => {
+      const [reciter] = await QuranFoundationAdapter.getReciters('ar');
+      expect(reciter.moshaf.playlist).toEqual([
+        {
+          surahId: '1',
+          link: 'https://download.quranicaudio.com/qdc/mishari_rashid_alafasy/murattal/1.mp3',
+        },
+        {
+          surahId: '2',
+          link: 'https://download.quranicaudio.com/qdc/mishari_rashid_alafasy/murattal/2.mp3',
+        },
+        {
+          surahId: '3',
+          link: 'https://download.quranicaudio.com/qdc/mishari_rashid_alafasy/murattal/3.mp3',
+        },
+      ]);
+    });
+
+    it('sets surah_total to the playlist length as a string', async () => {
+      const [reciter] = await QuranFoundationAdapter.getReciters('ar');
+      expect(reciter.moshaf.surah_total).toBe('3');
+    });
+
+    it('sets server to an empty string', async () => {
+      const [reciter] = await QuranFoundationAdapter.getReciters('ar');
+      expect(reciter.moshaf.server).toBe('');
+    });
+
+    it('throws when the token exchange fails', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 401,
+          json: vi.fn(),
+        } as unknown as Response)
+      );
+      await expect(QuranFoundationAdapter.getReciters('ar')).rejects.toThrow(
+        'access token'
+      );
+    });
+
+    it('throws when the reciters list endpoint keeps failing', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation((url: string) => {
+          if (url.includes('/oauth2/token')) {
+            return makeFetchResponse({ access_token: 't', expires_in: 3600 });
+          }
+          return Promise.resolve({
+            ok: false,
+            status: 500,
+            json: vi.fn(),
+          } as unknown as Response);
+        })
+      );
+      await expect(QuranFoundationAdapter.getReciters('ar')).rejects.toThrow(
+        'HTTP 500'
+      );
+    });
+
+    it('skips a reciter when its chapter audio fetch fails', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation((url: string) => {
+          if (url.includes('/oauth2/token')) {
+            return makeFetchResponse({ access_token: 't', expires_in: 3600 });
+          }
+          if (url.includes('chapter_reciters')) {
+            return makeFetchResponse(makeChapterRecitersResponse());
+          }
+          return Promise.resolve({
+            ok: false,
+            status: 500,
+            json: vi.fn(),
+          } as unknown as Response);
+        })
+      );
+
+      const reciters = await QuranFoundationAdapter.getReciters('ar');
+      expect(reciters).toHaveLength(0);
+    });
+
+    it('returns results from successful reciters even when some fail', async () => {
+      const twoReciters: QuranFoundationChapterRecitersResponse = {
+        reciters: [
+          ...makeChapterRecitersResponse().reciters,
+          {
+            id: 9,
+            name: 'Warsh Reciter',
+            qirat: { name: 'Warsh', language_name: 'english' },
+            translated_name: {
+              name: 'Warsh Reciter',
+              language_name: 'english',
+            },
+          },
+        ],
+      };
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation((url: string) => {
+          if (url.includes('/oauth2/token')) {
+            return makeFetchResponse({ access_token: 't', expires_in: 3600 });
+          }
+          if (url.includes('chapter_reciters')) {
+            return makeFetchResponse(twoReciters);
+          }
+          if (url.includes('chapter_recitations/7')) {
+            return makeFetchResponse(makeChapterAudioResponse());
+          }
+          return Promise.resolve({
+            ok: false,
+            status: 500,
+            json: vi.fn(),
+          } as unknown as Response);
+        })
+      );
+
+      const reciters = await QuranFoundationAdapter.getReciters('ar');
+      expect(reciters).toHaveLength(1);
+      expect(reciters[0].id).toBe(`${LinkSource.QURAN_FOUNDATION}-7`);
+    });
+
+    it('returns an empty array when the reciters list is empty', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation((url: string) => {
+          if (url.includes('/oauth2/token')) {
+            return makeFetchResponse({ access_token: 't', expires_in: 3600 });
+          }
+          return makeFetchResponse({ reciters: [] });
+        })
+      );
+      const reciters = await QuranFoundationAdapter.getReciters('ar');
+      expect(reciters).toEqual([]);
+    });
+
+    it('skips reciters with no name', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation((url: string) => {
+          if (url.includes('/oauth2/token')) {
+            return makeFetchResponse({ access_token: 't', expires_in: 3600 });
+          }
+          if (url.includes('chapter_recitations')) {
+            return makeFetchResponse(makeChapterAudioResponse());
+          }
+          return makeFetchResponse({
+            reciters: [{ id: 3, name: '' }],
+          });
+        })
+      );
+
+      const reciters = await QuranFoundationAdapter.getReciters('ar');
+      expect(reciters).toEqual([]);
+    });
+
+    it('serializes concurrent invocations through one queue', async () => {
+      const results = await Promise.all([
+        QuranFoundationAdapter.getReciters('ar'),
+        QuranFoundationAdapter.getReciters('en'),
+      ]);
+      expect(results[0]).toHaveLength(1);
+      expect(results[1]).toHaveLength(1);
+      // First run (ar): token + list + audio; second run (en) reuses the cached token.
+      expect(fetch).toHaveBeenCalledTimes(5);
+    });
+  });
+});

--- a/src/services/reciters/quranfoundation.adapter.ts
+++ b/src/services/reciters/quranfoundation.adapter.ts
@@ -1,0 +1,232 @@
+import type { Playlist, Reciter } from '@/types';
+import { LinkSource, Riwaya } from '@/types';
+
+import type {
+  QuranFoundationChapterAudioResponse,
+  QuranFoundationChapterRecitersResponse,
+  QuranFoundationTokenResponse,
+} from './quranfoundation.types';
+import type { ReciterSource } from './reciter-source';
+import { retryFetch } from './shared-fetch';
+
+const DEFAULT_TOKEN_URL = 'https://oauth2.quran.foundation/oauth2/token';
+const DEFAULT_API_BASE = 'https://apis.quran.foundation';
+
+const CHAPTER_RECITERS_PATH = '/content/api/v4/resources/chapter_reciters';
+const CHAPTER_AUDIO_PATH = '/content/api/v4/chapter_recitations';
+
+// OAuth2 client credentials — server-only, never committed.
+const CLIENT_ID_ENV_VAR = 'QURAN_FOUNDATION_CLIENT_ID';
+const CLIENT_SECRET_ENV_VAR = 'QURAN_FOUNDATION_CLIENT_SECRET';
+// Optional overrides (used to point at the prelive/test gateway).
+const TOKEN_URL_ENV_VAR = 'QURAN_FOUNDATION_TOKEN_URL';
+const API_BASE_ENV_VAR = 'QURAN_FOUNDATION_API_BASE';
+
+// Pace requests to stay under the ~60 req/min free tier (0 disables pacing; used by tests).
+const RATE_LIMIT_MS_ENV_VAR = 'QURAN_FOUNDATION_RATE_LIMIT_MS';
+const DEFAULT_RATE_LIMIT_MS = 1100;
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+// Client-credentials tokens expire hourly; cache until shortly before expiry.
+let cachedToken: { value: string; expiresAt: number } | null = null;
+
+// Cache results in-process so SSG/build and concurrent calls don't hammer the provider.
+const RESULTS_CACHE_TTL_MS = 55 * 60_000;
+const resultsCache = new Map<
+  'ar' | 'en',
+  { reciters: Reciter[]; expiresAt: number }
+>();
+
+/** Test/debug helper: clears the cached access token and results. */
+export const resetQuranFoundationCache = (): void => {
+  cachedToken = null;
+  resultsCache.clear();
+};
+
+const readEnvironment = (name: string): string => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `${name} is not set; quran.foundation provider is disabled`
+    );
+  }
+  return value;
+};
+
+const rateLimitMs = (): number => {
+  const override = Number(process.env[RATE_LIMIT_MS_ENV_VAR]);
+  return Number.isFinite(override) && override >= 0
+    ? override
+    : DEFAULT_RATE_LIMIT_MS;
+};
+
+/** Exchanges client credentials for a fresh access token (cached hourly). */
+const getAccessToken = async (): Promise<string> => {
+  if (cachedToken && cachedToken.expiresAt > Date.now() + 60_000) {
+    return cachedToken.value;
+  }
+
+  const clientId = readEnvironment(CLIENT_ID_ENV_VAR);
+  const clientSecret = readEnvironment(CLIENT_SECRET_ENV_VAR);
+  const tokenUrl = process.env[TOKEN_URL_ENV_VAR] || DEFAULT_TOKEN_URL;
+
+  let response: Response;
+  try {
+    response = await retryFetch(
+      tokenUrl,
+      3,
+      rateLimitMs() > 0 ? delay : async () => {},
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: `Basic ${Buffer.from(
+            `${clientId}:${clientSecret}`
+          ).toString('base64')}`,
+        },
+        body: 'grant_type=client_credentials&scope=content',
+      }
+    );
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to fetch quran.foundation access token (${reason})`
+    );
+  }
+
+  const data = (await response.json()) as QuranFoundationTokenResponse;
+
+  if (!data.access_token) {
+    throw new Error('quran.foundation token response missing access_token');
+  }
+
+  // Buffer 60s so the token is refreshed before it actually expires.
+  cachedToken = {
+    value: data.access_token,
+    expiresAt: Date.now() + (data.expires_in ?? 3600) * 1000 - 60_000,
+  };
+
+  return cachedToken.value;
+};
+
+/** Maps the API's `qirat.name` (e.g. "Hafs") to a Riwaya key, default Hafs. */
+const riwayaKeyFromQirat = (qirat?: string | null): keyof typeof Riwaya =>
+  (Object.keys(Riwaya) as Array<keyof typeof Riwaya>).find(
+    (key) => key.toLowerCase() === (qirat ?? '').toLowerCase()
+  ) ?? 'Hafs';
+
+// Serialize concurrent calls so pacing stays under the free-tier limit.
+let queue: Promise<unknown> = Promise.resolve();
+
+export const QuranFoundationAdapter: ReciterSource = {
+  source: LinkSource.QURAN_FOUNDATION,
+
+  getReciters(lang: 'ar' | 'en'): Promise<Reciter[]> {
+    const run = async (): Promise<Reciter[]> => {
+      const cached = resultsCache.get(lang);
+      if (cached && cached.expiresAt > Date.now()) {
+        return cached.reciters;
+      }
+
+      const token = await getAccessToken();
+      const clientId = readEnvironment(CLIENT_ID_ENV_VAR);
+      const intervalMs = rateLimitMs();
+      const backoff = intervalMs > 0 ? delay : async () => {};
+      const apiBase = process.env[API_BASE_ENV_VAR] || DEFAULT_API_BASE;
+
+      const fetchWithThrottle = async (url: string): Promise<Response> => {
+        const response = await retryFetch(url, 3, backoff, {
+          headers: {
+            'x-auth-token': token,
+            'x-client-id': clientId,
+          },
+        });
+        if (intervalMs > 0) {
+          await delay(intervalMs);
+        }
+        return response;
+      };
+
+      const listResponse = await fetchWithThrottle(
+        `${apiBase}${CHAPTER_RECITERS_PATH}?language=${lang}`
+      );
+
+      const listData: QuranFoundationChapterRecitersResponse =
+        await listResponse.json();
+
+      if (!Array.isArray(listData.reciters)) {
+        throw new Error('Unexpected quran.foundation reciters response');
+      }
+
+      const results: Array<Reciter | null> = [];
+
+      for (const reciter of listData.reciters) {
+        try {
+          const audioResponse = await fetchWithThrottle(
+            `${apiBase}${CHAPTER_AUDIO_PATH}/${reciter.id}`
+          );
+          const audioData: QuranFoundationChapterAudioResponse =
+            await audioResponse.json();
+
+          if (!Array.isArray(audioData.audio_files)) {
+            throw new Error(
+              `Unexpected audio response for reciter ${reciter.id}`
+            );
+          }
+
+          const name = reciter.translated_name?.name ?? reciter.name ?? '';
+
+          if (!name) {
+            console.warn(
+              `Skipping quran.foundation reciter ${reciter.id}: missing name`
+            );
+            results.push(null);
+            continue;
+          }
+
+          const playlist: Playlist = [...audioData.audio_files]
+            .sort((a, b) => a.chapter_id - b.chapter_id)
+            .map((audioFile) => ({
+              surahId: String(audioFile.chapter_id),
+              link: audioFile.audio_url,
+            }));
+
+          const riwayaKey = riwayaKeyFromQirat(reciter.qirat?.name);
+
+          results.push({
+            id: `${LinkSource.QURAN_FOUNDATION}-${reciter.id}`,
+            name,
+            source: LinkSource.QURAN_FOUNDATION,
+            moshaf: {
+              id: String(reciter.id),
+              name,
+              riwaya: Riwaya[riwayaKey],
+              server: '',
+              surah_total: String(playlist.length),
+              playlist,
+            },
+          } satisfies Reciter);
+        } catch (error) {
+          console.warn(
+            `Skipping quran.foundation reciter ${reciter.id}:`,
+            error
+          );
+          results.push(null);
+        }
+      }
+
+      const reciters = results.filter((r): r is Reciter => r !== null);
+      resultsCache.set(lang, {
+        reciters,
+        expiresAt: Date.now() + RESULTS_CACHE_TTL_MS,
+      });
+      return reciters;
+    };
+
+    const result = queue.then(run, run);
+    queue = result.catch(() => {});
+    return result;
+  },
+};

--- a/src/services/reciters/quranfoundation.types.ts
+++ b/src/services/reciters/quranfoundation.types.ts
@@ -1,0 +1,46 @@
+/** Quran Foundation content API types (v4-aligned, verified live against prelive). */
+
+export type QuranFoundationChapterReciter = {
+  id: number;
+  name: string;
+  style?: {
+    name?: string;
+    translated_name?: { name: string; language_name: string };
+  } | null;
+  /** Riwaya, e.g. "Hafs" or "Warsh". */
+  qirat?: { name?: string; language_name?: string } | null;
+  translated_name?: { name: string; language_name: string };
+};
+
+export type QuranFoundationChapterRecitersResponse = {
+  reciters: QuranFoundationChapterReciter[];
+};
+
+/** Word/verse segment timestamps (ms); only verse-level endpoints return them yet. */
+export type QuranFoundationSegment = {
+  verse_key: string;
+  timestamp_from: number;
+  timestamp_to: number;
+  /** Word-level segment data; shape varies by endpoint. */
+  segments?: unknown[];
+};
+
+export type QuranFoundationAudioFile = {
+  id: number;
+  chapter_id: number;
+  audio_url: string;
+  file_size?: number;
+  format?: string;
+  /** Present only on endpoints that return segments. */
+  segments?: QuranFoundationSegment[];
+};
+
+export type QuranFoundationChapterAudioResponse = {
+  audio_files: QuranFoundationAudioFile[];
+};
+
+export type QuranFoundationTokenResponse = {
+  access_token?: string;
+  expires_in?: number;
+  scope?: string;
+};

--- a/src/services/reciters/shared-fetch.ts
+++ b/src/services/reciters/shared-fetch.ts
@@ -1,11 +1,15 @@
+// Type-only DOM global; derive it from fetch's signature to satisfy ESLint no-undef.
+type FetchOptions = Parameters<typeof fetch>[1];
+
 export const fetchWithTimeout = (
   url: string,
-  timeoutMs = 10_000
+  timeoutMs = 10_000,
+  init?: FetchOptions
 ): Promise<Response> => {
   let timeoutId: ReturnType<typeof setTimeout>;
 
   return Promise.race([
-    fetch(url),
+    fetch(url, init),
     new Promise<Response>((_, reject) => {
       timeoutId = setTimeout(
         () => reject(new Error('Fetch timeout')),
@@ -21,13 +25,14 @@ const defaultDelay = (ms: number) =>
 export const retryFetch = async (
   url: string,
   maxAttempts = 3,
-  delayFunction: (ms: number) => Promise<void> = defaultDelay
+  delayFunction: (ms: number) => Promise<void> = defaultDelay,
+  init?: FetchOptions
 ): Promise<Response> => {
   let lastError: Error | null = null;
 
   for (let index = 0; index < maxAttempts; index++) {
     try {
-      const response = await fetchWithTimeout(url);
+      const response = await fetchWithTimeout(url, 10_000, init);
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       return response;
     } catch (error) {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -38,6 +38,10 @@ const quranAudioCache = {
     if (url.hostname.includes('itqan')) {
       return true;
     }
+    // Match Quran Foundation audio CDN
+    if (url.hostname.endsWith('quranicaudio.com')) {
+      return true;
+    }
     return false;
   },
   handler: new CacheFirst({
@@ -61,7 +65,8 @@ self.addEventListener('fetch', (event) => {
     (url.hostname.endsWith('.mp3quran.net') &&
       /^server\d+$/.test(url.hostname.split('.')[0]) &&
       /^\d+\.mp3$/.test(url.pathname.slice(1))) ||
-    url.hostname.includes('itqan');
+    url.hostname.includes('itqan') ||
+    url.hostname.endsWith('quranicaudio.com');
 
   if (isAudio) {
     event.respondWith(

--- a/src/types/link-source.ts
+++ b/src/types/link-source.ts
@@ -1,6 +1,7 @@
 export enum LinkSource {
   MP3QURAN = 'mp3quran.net',
   ITQAN = 'itqan.dev',
+  QURAN_FOUNDATION = 'quran.foundation',
   ISLAMHOUSE = 'islamhouse.com',
   INTERNETARCHIVE = 'archive.org',
   UNKNOWN = 'unknown',


### PR DESCRIPTION
## Description
 
Adds quran.foundation (https://api-docs.quran.foundation/) as a fourth audio
reciter source, following the same adapter/enabled-sources/persistence
conventions as mp3quran and itqan. The adapter uses OAuth2 client-credentials
(server-side only), respects the ~60 req/min free tier via paced requests, and
caches tokens/results in-process.
 
Fixes #74
 
## Type of change
 
- [x] New feature (non-breaking)
 
## Changes
 
- New `QuranFoundationAdapter` + types + 23 unit tests
- New `LinkSource.QURAN_FOUNDATION` source, registered in the adapter registry
- Settings toggle, reciter-card badge, i18n (en + ar)
- Service-worker audio matcher for the quran.foundation CDN
- `.env.example` documents `QURAN_FOUNDATION_CLIENT_ID/SECRET` (+ optional
  `QURAN_FOUNDATION_TOKEN_URL` / `QURAN_FOUNDATION_API_BASE` overrides)
 
## Known data issue (verified live)
 
Reciter **id `quran.foundation-173` ("Mishari Rashid al-Afasy Streaming")**
has no Arabic translation: the API returns translated_name.language_name:
"english" even when requesting language=ar, so its name renders
English-only in the Arabic UI. This is upstream data (not a UI string, so no
translation key applies); flagged here so it can be raised with the provider
or filtered in a follow-up.
 
## Note: deviations from the issue spec
 
The live API differs from the issue's description (verified with credentials):
 
- Base is `https://apis.quran.foundation` (not `api.quran.foundation/api/v1`)
- Auth is OAuth2 client-credentials with `x-auth-token` + `x-client-id` headers
  (not a static key via `auth-token`)
- Recitations are listed via `/content/api/v4/resources/chapter_reciters`
  (`id`/`name`/`style`/`qirat`); chapter audio is
  `/content/api/v4/chapter_recitations/{id}` (114 surah files per call)
- The chapter endpoint does not return `segments`; the field is captured in
  the types for future verse-level usage
 
## Testing
 
- [x] `yarn format:check`
- [x] `yarn lint`
- [x] `yarn type-check`
- [x] `yarn test:coverage` (225 passed; coverage ~95%)
- [x] `yarn build`
- [x] Manual QA on `yarn dev` (routes exercised: /settings, /, /api/reciters)
 
## Screenshots
 
<img width="1918" height="967" alt="open-tarteel-2" src="https://github.com/user-attachments/assets/c98e7ec9-2a5b-47a0-a5c5-8b8168984046" />
<img width="1918" height="967" alt="open-tarteel-1" src="https://github.com/user-attachments/assets/69b576db-8f6f-4298-95d5-f8a62e74a656" />
 
## Checklist
 
- [x] Branched from the default base (`develop`)
- [x] My code follows the style guidelines in `eslint.config.mjs` and `.prettierrc.mjs`
- [x] I have performed a self-review of the diff
- [x] I have updated docs / `CHANGELOG.md` where appropriate
- [x] I have added or updated tests for new behavior
- [x] No new warnings from `yarn lint` or `yarn build`
- [x] Related issue linked (`Fixes #74`)
 
---
 
*AI assistance disclosure: some code in this PR was AI-assisted and has been manually reviewed.*